### PR TITLE
Configure deprovision API's

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,2 @@
 ## 0.0.0
+ - The deprovision API's can be configured in `app/config/parameters.yml`. For more information see the README.md and `parameters.yml.dist` files.

--- a/README.md
+++ b/README.md
@@ -9,6 +9,23 @@
 # OpenConext User Lifecycle
 Deprovision users within the OpenConext platform. Teh User Lifecycle application is where the last login information of OpenConext suite users is stored. From this application you can trigger the deprovisioning of users that are no longer considered active users.
 
+## Configuring deprovision clients
+A deprovision client is an OpenConext suite app that implements the deprovisioning API. And can therefor be used by OpenConext User Lifecycle to deprovision users from the platform. To configure a client, please update the `app/config/parameters.yml` file. For each client provide an entry in the `open_conext_user_lifecycle_clients` configuration section. An example can be found below.
+
+```yaml
+open_conext_user_lifecycle_clients:
+    openconext_engineblock:
+        url: 'https://engine.example.com/path/to/api/'
+        username: 'my-user-name'
+        password: 'secret'
+        verify_ssl: false
+    teams:
+        url: 'https://teams.example.com/api'
+        username: 'deprovision'
+        password: 'secret'
+``` 
+
+For more information about setting up the clients, see the `parameters.yml.dist` file.
 
 ## Deprovisioning a user
 TODO: describe DELETE feature and its --dry-run option.

--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -14,6 +14,7 @@ class AppKernel extends Kernel
             new Symfony\Bundle\FrameworkBundle\FrameworkBundle(),
             new Symfony\Bundle\MonologBundle\MonologBundle(),
             new Symfony\Bundle\SecurityBundle\SecurityBundle(),
+            new OpenConext\UserLifecycle\Infrastructure\UserLifecycleBundle\UserLifecycleBundle(),
         ];
 
         if (in_array($this->getEnvironment(), ['dev', 'test'], true)) {

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -43,3 +43,5 @@ monolog:
             type: console
             channels: ['!event', '!doctrine']
 
+open_conext_user_lifecycle:
+    clients: %open_conext_user_lifecycle_clients%

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -43,5 +43,5 @@ monolog:
             type: console
             channels: ['!event', '!doctrine']
 
-open_conext_user_lifecycle:
-    clients: %open_conext_user_lifecycle_clients%
+user_lifecycle:
+     clients: %open_conext_user_lifecycle_clients%

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -12,3 +12,15 @@ parameters:
 
     # A secret key that's used to generate certain security-related tokens
     secret: ThisTokenIsNotSoSecretChangeIt
+
+    # The clients should be configured with an api url, username and password. Basic auth is the only supported auth
+    # mechanism at this point.
+    open_conext_user_lifecycle_clients:
+        # The service name is used for naming the dynamically created service and should be written in snake case
+        my_service_name:
+            # The API Url excluding the endpoint
+            url: 'https://my-service-url/api/'
+            username: 'my-user-name'
+            password: 'secret'
+            # By default ssl verification is enabled, can be switched of by setting it to false
+            verify_ssl: false

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "type": "project",
     "autoload": {
         "psr-4": {
-            "Surfnet\\": "src/OpenConext"
+            "OpenConext\\": "src/OpenConext"
         },
         "classmap": [
             "app/AppKernel.php",
@@ -14,7 +14,7 @@
     },
     "autoload-dev": {
         "psr-4": {
-            "Surfnet\\": "src\\OpenConext"
+            "OpenConext\\": "src\\OpenConext"
         },
         "files": [
             "vendor/symfony/symfony/src/Symfony/Component/VarDumper/Resources/functions/dump.php"

--- a/src/OpenConext/UserLifecycle/Domain/Client/DeprovisionClient.php
+++ b/src/OpenConext/UserLifecycle/Domain/Client/DeprovisionClient.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * Copyright 2018 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenConext\UserLifecycle\Domain\Client;
+
+use OpenConext\UserLifecycle\Domain\ValueObject\CollabPersonId;
+
+interface DeprovisionClient
+{
+    /**
+     * Can be used to deprovision a user from the OpenConext platform.
+     *
+     * @param CollabPersonId $user
+     * @param bool $dryRun
+     */
+    public function deprovision(CollabPersonId $user, $dryRun = false);
+
+    /**
+     * Can be used to gather information about a user on the OpenConext platform.
+     *
+     * @param CollabPersonId|null $user
+     */
+    public function information(CollabPersonId $user);
+}

--- a/src/OpenConext/UserLifecycle/Domain/Client/DeprovisionClientCollectionInterface.php
+++ b/src/OpenConext/UserLifecycle/Domain/Client/DeprovisionClientCollectionInterface.php
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * Copyright 2018 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenConext\UserLifecycle\Domain\Client;
+
+interface DeprovisionClientCollectionInterface extends DeprovisionClientInterface
+{
+    public function addClient(DeprovisionClientInterface $client);
+}

--- a/src/OpenConext/UserLifecycle/Domain/Client/DeprovisionClientInterface.php
+++ b/src/OpenConext/UserLifecycle/Domain/Client/DeprovisionClientInterface.php
@@ -20,7 +20,7 @@ namespace OpenConext\UserLifecycle\Domain\Client;
 
 use OpenConext\UserLifecycle\Domain\ValueObject\CollabPersonId;
 
-interface DeprovisionClient
+interface DeprovisionClientInterface
 {
     /**
      * Can be used to deprovision a user from the OpenConext platform.
@@ -36,4 +36,11 @@ interface DeprovisionClient
      * @param CollabPersonId|null $user
      */
     public function information(CollabPersonId $user);
+
+    /**
+     * Returns the name of the client, as configured in the parameters.yml
+     *
+     * @return string
+     */
+    public function getName();
 }

--- a/src/OpenConext/UserLifecycle/Domain/ValueObject/CollabPersonId.php
+++ b/src/OpenConext/UserLifecycle/Domain/ValueObject/CollabPersonId.php
@@ -1,0 +1,46 @@
+<?php
+
+/**
+ * Copyright 2018 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenConext\UserLifecycle\Domain\ValueObject;
+
+use Webmozart\Assert\Assert;
+
+class CollabPersonId
+{
+    /**
+     * @var string
+     */
+    private $collabUserId;
+
+    public function __construct($collabUserId)
+    {
+        if (is_string($collabUserId)) {
+            $collabUserId = trim($collabUserId);
+        }
+        Assert::stringNotEmpty($collabUserId, 'The collabUserId must be a non empty string');
+        $this->collabUserId = $collabUserId;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getCollabUserId()
+    {
+        return $this->collabUserId;
+    }
+}

--- a/src/OpenConext/UserLifecycle/Infrastructure/UserLifecycleBundle/Client/DeprovisionClient.php
+++ b/src/OpenConext/UserLifecycle/Infrastructure/UserLifecycleBundle/Client/DeprovisionClient.php
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * Copyright 2018 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenConext\UserLifecycle\Infrastructure\UserLifecycleBundle\Client;
+
+use GuzzleHttp\ClientInterface;
+use OpenConext\UserLifecycle\Domain\Client\DeprovisionClientInterface;
+use OpenConext\UserLifecycle\Domain\ValueObject\CollabPersonId;
+
+class DeprovisionClient implements DeprovisionClientInterface
+{
+    /**
+     * @var ClientInterface
+     */
+    private $httpClient;
+
+    public function __construct(ClientInterface $httpClient)
+    {
+        $this->httpClient = $httpClient;
+    }
+
+    public function deprovision(CollabPersonId $user, $dryRun = false)
+    {
+
+    }
+
+    public function information(CollabPersonId $user)
+    {
+
+    }
+
+    public function getName()
+    {
+    }
+}

--- a/src/OpenConext/UserLifecycle/Infrastructure/UserLifecycleBundle/Client/DeprovisionClientCollection.php
+++ b/src/OpenConext/UserLifecycle/Infrastructure/UserLifecycleBundle/Client/DeprovisionClientCollection.php
@@ -1,0 +1,55 @@
+<?php
+
+/**
+ * Copyright 2018 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenConext\UserLifecycle\Infrastructure\UserLifecycleBundle\Client;
+
+use OpenConext\UserLifecycle\Domain\Client\DeprovisionClientCollectionInterface;
+use OpenConext\UserLifecycle\Domain\Client\DeprovisionClientInterface;
+use OpenConext\UserLifecycle\Domain\ValueObject\CollabPersonId;
+
+class DeprovisionClientCollection implements DeprovisionClientCollectionInterface
+{
+    /**
+     * @var DeprovisionClientInterface[]
+     */
+    private $clients;
+
+    public function deprovision(CollabPersonId $user, $dryRun = false)
+    {
+        foreach ($this->clients as $client){
+            $client->deprovision($user, $dryRun);
+        }
+    }
+
+    public function information(CollabPersonId $user)
+    {
+        foreach ($this->clients as $client){
+            $client->information($user);
+        }
+    }
+
+    public function getName()
+    {
+        return 'DeprovisionClientCollection';
+    }
+
+    public function addClient(DeprovisionClientInterface $client)
+    {
+        $this->clients[$client->getName()] = $client;
+    }
+}

--- a/src/OpenConext/UserLifecycle/Infrastructure/UserLifecycleBundle/DependencyInjection/Compiler/DeprovisionClientCollectionPass.php
+++ b/src/OpenConext/UserLifecycle/Infrastructure/UserLifecycleBundle/DependencyInjection/Compiler/DeprovisionClientCollectionPass.php
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * Copyright 2018 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenConext\UserLifecycle\Infrastructure\UserLifecycleBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * The deprovision client collection is registered with the services tagged with
+ * 'open_conext.user_lifecycle.deprovision_client'.
+ */
+class DeprovisionClientCollectionPass implements CompilerPassInterface
+{
+    /**
+     * @SuppressWarnings(PHPMD.UnusedLocalVariable) $tags is never used in the foreach
+     * @param ContainerBuilder $container
+     */
+    public function process(ContainerBuilder $container)
+    {
+        if (!$container->has('open_conext.user_lifecycle.deprovision_client_collection')) {
+            return;
+        }
+
+        $definition = $container->findDefinition('open_conext.user_lifecycle.deprovision_client_collection');
+
+        // find all service IDs with the open_conext.user_lifecycle.deprovision_client tag
+        $taggedServices = $container->findTaggedServiceIds('open_conext.user_lifecycle.deprovision_client');
+
+        foreach ($taggedServices as $id => $tags) {
+            $definition->addMethodCall('addHealthCheck', array(new Reference($id)));
+        }
+    }
+}

--- a/src/OpenConext/UserLifecycle/Infrastructure/UserLifecycleBundle/DependencyInjection/Configuration.php
+++ b/src/OpenConext/UserLifecycle/Infrastructure/UserLifecycleBundle/DependencyInjection/Configuration.php
@@ -1,0 +1,74 @@
+<?php
+
+/**
+ * Copyright 2018 SURFnet bv
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenConext\UserLifecycle\Infrastructure\UserLifecycleBundle\DependencyInjection;
+
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
+
+class Configuration implements ConfigurationInterface
+{
+    public function getConfigTreeBuilder()
+    {
+        $treeBuilder = new TreeBuilder();
+
+        $treeBuilder
+            ->root('open_conext_user_lifecycle')
+                ->children()
+                    ->arrayNode('clients')
+                        ->info('Configures the deprovision clients.')
+                        ->isRequired()
+                        ->addDefaultsIfNotSet()
+                        ->children()
+                            ->scalarNode('url')
+                                ->isRequired()
+                                ->validate()
+                                    ->ifTrue(function ($url) {
+                                        return !is_string($url) || empty($url);
+                                    })
+                                    ->thenInvalid("Url must be non-empty string, got '%s'")
+                                ->end()
+                            ->end()
+                            ->scalarNode('username')
+                                ->isRequired()
+                                ->validate()
+                                    ->ifTrue(function ($username) {
+                                        return !is_string($username) || empty($username);
+                                    })
+                                    ->thenInvalid("Username must be non-empty string, got '%s'")
+                                ->end()
+                            ->end()
+                            ->scalarNode('password')
+                                ->isRequired()
+                                ->validate()
+                                    ->ifTrue(function ($password) {
+                                        return !is_string($password) || empty($password);
+                                    })
+                                    ->thenInvalid("Password must be non-empty string, got '%s'")
+                                ->end()
+                            ->end()
+                            ->booleanNode('verify_ssl')
+                                ->defaultValue(true)
+                            ->end()
+                        ->end()
+                    ->end()
+                ->end();
+
+        return $treeBuilder;
+    }
+}

--- a/src/OpenConext/UserLifecycle/Infrastructure/UserLifecycleBundle/DependencyInjection/UserLifecycleExtension.php
+++ b/src/OpenConext/UserLifecycle/Infrastructure/UserLifecycleBundle/DependencyInjection/UserLifecycleExtension.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * Copyright 2018 SURFnet bv
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenConext\UserLifecycle\Infrastructure\UserLifecycleBundle\DependencyInjection;
+
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+
+class UserLifecycleExtension extends Extension
+{
+    public function load(array $config, ContainerBuilder $container)
+    {
+    }
+}

--- a/src/OpenConext/UserLifecycle/Infrastructure/UserLifecycleBundle/Resources/config/services.yml
+++ b/src/OpenConext/UserLifecycle/Infrastructure/UserLifecycleBundle/Resources/config/services.yml
@@ -1,4 +1,3 @@
 services:
-#    user_lifecycle.example:
-#        class: UserLifecycleBundle\Example
-#        arguments: ["@service_id", "plain_value", "%parameter%"]
+    open_conext.user_lifecycle.deprovision_client_collection:
+        class: OpenConext\UserLifecycle\Infrastructure\UserLifecycleBundle\Client\DeprovisionClientCollection

--- a/src/OpenConext/UserLifecycle/Infrastructure/UserLifecycleBundle/Resources/config/services.yml
+++ b/src/OpenConext/UserLifecycle/Infrastructure/UserLifecycleBundle/Resources/config/services.yml
@@ -1,0 +1,4 @@
+services:
+#    user_lifecycle.example:
+#        class: UserLifecycleBundle\Example
+#        arguments: ["@service_id", "plain_value", "%parameter%"]

--- a/src/OpenConext/UserLifecycle/Infrastructure/UserLifecycleBundle/UserLifecycleBundle.php
+++ b/src/OpenConext/UserLifecycle/Infrastructure/UserLifecycleBundle/UserLifecycleBundle.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace OpenConext\UserLifecycle\Infrastructure\UserLifecycleBundle;
+
+use Symfony\Component\HttpKernel\Bundle\Bundle;
+
+class UserLifecycleBundle extends Bundle
+{
+}

--- a/src/OpenConext/UserLifecycle/Infrastructure/UserLifecycleBundle/UserLifecycleBundle.php
+++ b/src/OpenConext/UserLifecycle/Infrastructure/UserLifecycleBundle/UserLifecycleBundle.php
@@ -2,8 +2,16 @@
 
 namespace OpenConext\UserLifecycle\Infrastructure\UserLifecycleBundle;
 
+use OpenConext\UserLifecycle\Infrastructure\UserLifecycleBundle\DependencyInjection\Compiler\DeprovisionClientCollectionPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 class UserLifecycleBundle extends Bundle
 {
+    public function build(ContainerBuilder $container)
+    {
+        parent::build($container);
+
+        $container->addCompilerPass(new DeprovisionClientCollectionPass());
+    }
 }

--- a/tests/unit/Domain/ValueObject/CollabPersonIdTest.php
+++ b/tests/unit/Domain/ValueObject/CollabPersonIdTest.php
@@ -1,0 +1,55 @@
+<?php
+
+/**
+ * Copyright 2018 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenConext\UserLifecycle\Tests\Unit\Domain\ValueObject;
+
+use OpenConext\UserLifecycle\Domain\ValueObject\CollabPersonId;
+use PHPUnit\Framework\TestCase;
+
+class CollabPersonIdTest extends TestCase
+{
+    public function test_can_be_created()
+    {
+        $user = new CollabPersonId('urn:mace:example.com:jan');
+        $this->assertEquals('urn:mace:example.com:jan', $user->getCollabUserId());
+    }
+
+    /**
+     * @dataProvider invalidArguments
+     * @param $invalidArgument
+     */
+    public function test_must_be_non_empty_string($invalidArgument)
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The collabUserId must be a non empty string');
+
+        new CollabPersonId($invalidArgument);
+    }
+
+    public function invalidArguments()
+    {
+        return [
+            [''],
+            [' '],
+            [[]],
+            [null],
+            [true],
+            [['urn:mace:example.com:jan']]
+        ];
+    }
+}


### PR DESCRIPTION
The API's can be configured in the `parameters.yml` file. Sensible defaults have been added to the corresponding `dist` file.

* An outline for the Guzzle clients have been created
* DI Extension is responsible for configuring the clients and their collection.