### PR TITLE
Remove dependency on LastLoginByUserIdQueryHandler

### DIFF
--- a/tests/integration/UserLifecycleBundle/Resources/config/services.yml
+++ b/tests/integration/UserLifecycleBundle/Resources/config/services.yml
@@ -8,7 +8,6 @@ services:
         public: true
         class: OpenConext\UserLifecycle\Application\Service\LastLoginService
         arguments:
-            - '@OpenConext\UserLifecycle\Application\QueryHandler\LastLoginByUserIdQueryHandler'
             - '@open_conext.user_lifecycle.test.deprovision_client_collection'
             - '@logger'
 

--- a/tests/unit/Application/Service/LastLoginServiceTest.php
+++ b/tests/unit/Application/Service/LastLoginServiceTest.php
@@ -47,10 +47,9 @@ class LastLoginServiceTest extends TestCase
 
     public function setUp()
     {
-        $this->queryHandler = m::mock(LastLoginByUserIdQueryHandlerInterface::class);
         $this->apiCollection = m::mock(DeprovisionClientCollectionInterface::class);
         $logger = m::mock(LoggerInterface::class)->shouldIgnoreMissing();
-        $this->service = new LastLoginService($this->queryHandler, $this->apiCollection, $logger);
+        $this->service = new LastLoginService($this->apiCollection, $logger);
     }
 
     public function test_read_information_for()
@@ -59,10 +58,6 @@ class LastLoginServiceTest extends TestCase
         $personId = 'jay-leno';
 
         $lastLogin = m::mock(LastLogin::class)->makePartial();
-
-        $this->queryHandler
-            ->shouldReceive('handle')
-            ->andReturn($lastLogin);
 
         $this->apiCollection
             ->shouldReceive('information')
@@ -79,21 +74,6 @@ class LastLoginServiceTest extends TestCase
         $personId = '';
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Please pass a non empty collabPersonId');
-
-        $this->service->readInformationFor($personId);
-    }
-
-    public function test_read_information_for_no_last_login_entry()
-    {
-        // Setup the test using test doubles
-        $personId = 'janis_joplin';
-
-        $this->queryHandler
-            ->shouldReceive('handle')
-            ->andReturn(null);
-
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('No last_login entry found for user with collabPersonId "janis_joplin"');
 
         $this->service->readInformationFor($personId);
     }


### PR DESCRIPTION
The last login is not checked when reading the information console
action. This information is not required to read the user data from the
API's. This was a change in the requirements.

See comment in Pivotal for more info: https://www.pivotaltracker.com/story/show/157420015/comments/189551491