### PR TITLE
Log information response to log as info

### DIFF
--- a/src/OpenConext/UserLifecycle/Application/Service/LastLoginService.php
+++ b/src/OpenConext/UserLifecycle/Application/Service/LastLoginService.php
@@ -76,6 +76,13 @@ class LastLoginService implements LastLoginServiceInterface
         );
 
         $this->logger->debug('Retrieve the information from the APIs for the user.');
-        return $this->deprovisionClientCollection->information($collabPersonId);
+        $information = $this->deprovisionClientCollection->information($collabPersonId);
+
+        $this->logger->info(
+            sprintf('Received information for user "%s" with the following data.', $personId),
+            ['information_response' => $information]
+        );
+
+        return $information;
     }
 }


### PR DESCRIPTION
This ensures the response is not only displayed in the stdout but also
in the logs for later reference.