### PR TITLE
Inconsistent return type for DeprovisionClientCollection

### DIFF
--- a/src/OpenConext/UserLifecycle/Application/Client/InformationResponseFactory.php
+++ b/src/OpenConext/UserLifecycle/Application/Client/InformationResponseFactory.php
@@ -56,8 +56,27 @@ class InformationResponseFactory implements InformationResponseFactoryInterface
         $status = new ResponseStatus($response['status']);
         $name = new Name($response['name']);
         $data = new Data($response['data']);
-        $errorMessage = ErrorMessage::fromResponse($response, $status);
+        $errorMessage = $this->buildErrorMessage($response, $status);
 
         return new InformationResponse($status, $name, $data, $errorMessage);
+    }
+
+    private function buildErrorMessage(array $response, ResponseStatus $status)
+    {
+        // If status failed, we need an error message
+        if ($status->getStatus() === ResponseStatus::STATUS_FAILED) {
+            Assert::notEmpty($response['message']);
+        }
+
+        // If status OK, we do not want an error message
+        if ($status->getStatus() === ResponseStatus::STATUS_OK && isset($response['message'])) {
+            Assert::nullOrIsEmpty($response['message']);
+        }
+
+        if (isset($response['message']) && !empty($response['message'])) {
+            return new ErrorMessage($response['message']);
+        }
+        // If the message is not set, return an empty error message object
+        return new ErrorMessage();
     }
 }

--- a/src/OpenConext/UserLifecycle/Application/Client/InformationResponseFactory.php
+++ b/src/OpenConext/UserLifecycle/Application/Client/InformationResponseFactory.php
@@ -1,0 +1,63 @@
+<?php
+
+/**
+ * Copyright 2018 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenConext\UserLifecycle\Application\Client;
+
+use InvalidArgumentException;
+use OpenConext\UserLifecycle\Domain\Client\InformationResponse;
+use OpenConext\UserLifecycle\Domain\Client\InformationResponseFactoryInterface;
+use OpenConext\UserLifecycle\Domain\ValueObject\Client\Data;
+use OpenConext\UserLifecycle\Domain\ValueObject\Client\ErrorMessage;
+use OpenConext\UserLifecycle\Domain\ValueObject\Client\Name;
+use OpenConext\UserLifecycle\Domain\ValueObject\Client\ResponseStatus;
+use Webmozart\Assert\Assert;
+
+class InformationResponseFactory implements InformationResponseFactoryInterface
+{
+    /**
+     * Build an InformationResponse object from api response
+     *
+     * Input validation is applied based on there rules:
+     *  - name must be set (non empty string)
+     *  - status can be OK or FAILED (non empty string)
+     *  - data must be an array filled with at least name and value keys
+     *  - message must be set if status FAILED and must not be set if status OK
+     *
+     * @throws InvalidArgumentException
+     */
+    public function fromApiResponse(array $response)
+    {
+        // Test if the required fields are set in the response
+        $requiredFields = ['name', 'status', 'data'];
+        $errorMessage = null;
+
+        foreach ($requiredFields as $field) {
+            Assert::keyExists($response, $field);
+        }
+
+        Assert::isArray($response['data']);
+
+        // Build the individual value objects that make up the response object
+        $status = new ResponseStatus($response['status']);
+        $name = new Name($response['name']);
+        $data = new Data($response['data']);
+        $errorMessage = ErrorMessage::fromResponse($response, $status);
+
+        return new InformationResponse($status, $name, $data, $errorMessage);
+    }
+}

--- a/src/OpenConext/UserLifecycle/Application/Service/InformationService.php
+++ b/src/OpenConext/UserLifecycle/Application/Service/InformationService.php
@@ -20,7 +20,7 @@ namespace OpenConext\UserLifecycle\Application\Service;
 
 use InvalidArgumentException;
 use OpenConext\UserLifecycle\Domain\Client\DeprovisionClientCollectionInterface;
-use OpenConext\UserLifecycle\Domain\Client\InformationResponse;
+use OpenConext\UserLifecycle\Domain\Client\InformationResponseInterface;
 use OpenConext\UserLifecycle\Domain\Service\InformationServiceInterface;
 use OpenConext\UserLifecycle\Domain\ValueObject\CollabPersonId;
 use Psr\Log\LoggerInterface;
@@ -49,7 +49,7 @@ class InformationService implements InformationServiceInterface
     /**
      * @param string $personId
      * @throws InvalidArgumentException
-     * @return InformationResponse
+     * @return InformationResponseInterface
      */
     public function readInformationFor($personId)
     {

--- a/src/OpenConext/UserLifecycle/Application/Service/InformationService.php
+++ b/src/OpenConext/UserLifecycle/Application/Service/InformationService.php
@@ -60,7 +60,7 @@ class InformationService implements InformationServiceInterface
         $collabPersonId = new CollabPersonId($personId);
 
         $this->logger->debug('Retrieve the information from the APIs for the user.');
-        $information = $this->deprovisionClientCollection->information($collabPersonId);
+        $information = $this->deprovisionClientCollection->information($collabPersonId)->jsonSerialize();
 
         $this->logger->info(
             sprintf('Received information for user "%s" with the following data.', $personId),

--- a/src/OpenConext/UserLifecycle/Application/Service/InformationService.php
+++ b/src/OpenConext/UserLifecycle/Application/Service/InformationService.php
@@ -21,12 +21,12 @@ namespace OpenConext\UserLifecycle\Application\Service;
 use InvalidArgumentException;
 use OpenConext\UserLifecycle\Domain\Client\DeprovisionClientCollectionInterface;
 use OpenConext\UserLifecycle\Domain\Client\InformationResponse;
-use OpenConext\UserLifecycle\Domain\Service\LastLoginServiceInterface;
+use OpenConext\UserLifecycle\Domain\Service\InformationServiceInterface;
 use OpenConext\UserLifecycle\Domain\ValueObject\CollabPersonId;
 use Psr\Log\LoggerInterface;
 use Webmozart\Assert\Assert;
 
-class LastLoginService implements LastLoginServiceInterface
+class InformationService implements InformationServiceInterface
 {
     /**
      * @var DeprovisionClientCollectionInterface

--- a/src/OpenConext/UserLifecycle/Domain/Client/DeprovisionClientCollectionInterface.php
+++ b/src/OpenConext/UserLifecycle/Domain/Client/DeprovisionClientCollectionInterface.php
@@ -18,7 +18,23 @@
 
 namespace OpenConext\UserLifecycle\Domain\Client;
 
-interface DeprovisionClientCollectionInterface extends DeprovisionClientInterface
+use OpenConext\UserLifecycle\Domain\ValueObject\CollabPersonId;
+
+interface DeprovisionClientCollectionInterface
 {
     public function addClient(DeprovisionClientInterface $client);
+
+    /**
+     * @param CollabPersonId $user
+     * @param bool $dryRun
+     *
+     * @return InformationResponseCollectionInterface
+     */
+    public function deprovision(CollabPersonId $user, $dryRun = false);
+
+    /**
+     * @param CollabPersonId $user
+     * @return InformationResponseCollectionInterface
+     */
+    public function information(CollabPersonId $user);
 }

--- a/src/OpenConext/UserLifecycle/Domain/Client/DeprovisionClientInterface.php
+++ b/src/OpenConext/UserLifecycle/Domain/Client/DeprovisionClientInterface.php
@@ -36,7 +36,7 @@ interface DeprovisionClientInterface
      * Returns a Json encoded string containing the user information provided by the different deprovision API's.
      *
      * @param CollabPersonId|null $user
-     * @return InformationResponse
+     * @return InformationResponseInterface
      */
     public function information(CollabPersonId $user);
 

--- a/src/OpenConext/UserLifecycle/Domain/Client/InformationResponse.php
+++ b/src/OpenConext/UserLifecycle/Domain/Client/InformationResponse.php
@@ -19,14 +19,13 @@
 namespace OpenConext\UserLifecycle\Domain\Client;
 
 use InvalidArgumentException;
-use JsonSerializable;
 use OpenConext\UserLifecycle\Domain\ValueObject\Client\Data;
 use OpenConext\UserLifecycle\Domain\ValueObject\Client\ErrorMessage;
 use OpenConext\UserLifecycle\Domain\ValueObject\Client\Name;
 use OpenConext\UserLifecycle\Domain\ValueObject\Client\ResponseStatus;
 use Webmozart\Assert\Assert;
 
-class InformationResponse implements JsonSerializable
+class InformationResponse implements InformationResponseInterface
 {
     /**
      * @var ResponseStatus

--- a/src/OpenConext/UserLifecycle/Domain/Client/InformationResponse.php
+++ b/src/OpenConext/UserLifecycle/Domain/Client/InformationResponse.php
@@ -47,44 +47,12 @@ class InformationResponse implements InformationResponseInterface
      */
     private $errorMessage;
 
-    private function __construct(ResponseStatus $status, Name $name, Data $data, ErrorMessage $errorMessage = null)
+    public function __construct(ResponseStatus $status, Name $name, Data $data, ErrorMessage $errorMessage = null)
     {
         $this->status = $status;
         $this->name = $name;
         $this->data = $data;
         $this->errorMessage = $errorMessage;
-    }
-
-    /**
-     * Build an InformationResponse object from api response
-     *
-     * Input validation is applied based on there rules:
-     *  - name must be set (non empty string)
-     *  - status can be OK or FAILED (non empty string)
-     *  - data must be an array filled with at least name and value keys
-     *  - message must be set if status FAILED and must not be set if status OK
-     *
-     * @throws InvalidArgumentException
-     */
-    public static function fromApiResponse(array $response)
-    {
-        // Test if the required fields are set in the response
-        $requiredFields = ['name', 'status', 'data'];
-        $errorMessage = null;
-
-        foreach ($requiredFields as $field) {
-            Assert::keyExists($response, $field);
-        }
-
-        Assert::isArray($response['data']);
-
-        // Build the individual value objects that make up the response object
-        $status = new ResponseStatus($response['status']);
-        $name = new Name($response['name']);
-        $data = new Data($response['data']);
-        $errorMessage = ErrorMessage::fromResponse($response, $status);
-
-        return new InformationResponse($status, $name, $data, $errorMessage);
     }
 
     public function getStatus()

--- a/src/OpenConext/UserLifecycle/Domain/Client/InformationResponse.php
+++ b/src/OpenConext/UserLifecycle/Domain/Client/InformationResponse.php
@@ -18,12 +18,10 @@
 
 namespace OpenConext\UserLifecycle\Domain\Client;
 
-use InvalidArgumentException;
 use OpenConext\UserLifecycle\Domain\ValueObject\Client\Data;
 use OpenConext\UserLifecycle\Domain\ValueObject\Client\ErrorMessage;
 use OpenConext\UserLifecycle\Domain\ValueObject\Client\Name;
 use OpenConext\UserLifecycle\Domain\ValueObject\Client\ResponseStatus;
-use Webmozart\Assert\Assert;
 
 class InformationResponse implements InformationResponseInterface
 {

--- a/src/OpenConext/UserLifecycle/Domain/Client/InformationResponseCollection.php
+++ b/src/OpenConext/UserLifecycle/Domain/Client/InformationResponseCollection.php
@@ -1,0 +1,150 @@
+<?php
+
+/**
+ * Copyright 2018 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenConext\UserLifecycle\Domain\Client;
+
+use InvalidArgumentException;
+use JsonSerializable;
+use OpenConext\UserLifecycle\Domain\Exception\InformationResponseNotFoundException;
+use OpenConext\UserLifecycle\Domain\ValueObject\Client\Data;
+use OpenConext\UserLifecycle\Domain\ValueObject\Client\ErrorMessage;
+use OpenConext\UserLifecycle\Domain\ValueObject\Client\Name;
+use OpenConext\UserLifecycle\Domain\ValueObject\Client\ResponseStatus;
+use Webmozart\Assert\Assert;
+
+/**
+ * A collection of InformationResponse objects
+ *
+ * The data is a collection of InformationResponseCollection objects
+ * stored in a Data value object. The entries are indexed on the
+ * information response name of the child entry.
+ *
+ * By default the response status of the collection is OK, when an
+ * information response with the FAILED response status is appended
+ * to the collection, the status of the collection is also set to
+ * FAILED, as one of it's children failed.
+ *
+ * The name of the collection object is hard coded to
+ * 'InformationResponseCollection' as the name of the collection is
+ * irrelevant for now.
+ *
+ * The errorMessage field will be filled with the last error message
+ * that was encountered while adding an InformationResponse to the
+ * collection.
+ */
+class InformationResponseCollection implements InformationResponseInterface
+{
+    /**
+     * @var ResponseStatus
+     */
+    private $status;
+
+    /**
+     * @var Name
+     */
+    private $name;
+
+    /**
+     * @var Data
+     */
+    private $data;
+
+    /**
+     * @var ErrorMessage
+     */
+    private $errorMessage;
+
+    public function __construct()
+    {
+        $this->status = new ResponseStatus(ResponseStatus::STATUS_OK);
+        $this->name = new Name('InformationResponseCollection');
+        $this->data = Data::buildEmpty();
+    }
+
+    public function addInformationResponse(InformationResponseInterface $informationResponse)
+    {
+        if ($informationResponse->getStatus()->getStatus() != ResponseStatus::STATUS_OK) {
+            $this->status = $informationResponse->getStatus();
+        }
+
+        if ($informationResponse->getErrorMessage()->hasErrorMessage()) {
+            $this->errorMessage = $informationResponse->getErrorMessage();
+        }
+
+        $this->data->addInformationResponse(
+            (string)$informationResponse->getName(),
+            $informationResponse
+        );
+    }
+
+    /**
+     * @param $name
+     * @return InformationResponseInterface
+     *
+     * @throws InformationResponseNotFoundException
+     */
+    public function getByName($name)
+    {
+        foreach ($this->getData()->getData() as $entry) {
+            if ($entry[Data::VALID_DATA_FIELD_NAME] == $name) {
+                return $entry[Data::VALID_DATA_FIELD_VALUE];
+            }
+        }
+        throw new InformationResponseNotFoundException(
+            sprintf(
+                'InformationResponse with name "%s" cannot be found in collection',
+                $name
+            )
+        );
+    }
+
+    public function getStatus()
+    {
+        return $this->status;
+    }
+
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    public function getData()
+    {
+        return $this->data;
+    }
+
+    public function getErrorMessage()
+    {
+        return $this->errorMessage;
+    }
+
+    public function jsonSerialize()
+    {
+        $response = [
+            'name' => (string)$this->getName(),
+            'status' => (string)$this->getStatus(),
+            'data' => $this->getData()->getData(),
+        ];
+
+        if ($this->getErrorMessage()->hasErrorMessage()) {
+            $response['message'] = (string)$this->getErrorMessage();
+        }
+
+        return json_encode($response);
+    }
+}

--- a/src/OpenConext/UserLifecycle/Domain/Client/InformationResponseCollection.php
+++ b/src/OpenConext/UserLifecycle/Domain/Client/InformationResponseCollection.php
@@ -141,7 +141,7 @@ class InformationResponseCollection implements InformationResponseInterface
             'data' => $this->getData()->getData(),
         ];
 
-        if ($this->getErrorMessage()->hasErrorMessage()) {
+        if ($this->getErrorMessage() && $this->getErrorMessage()->hasErrorMessage()) {
             $response['message'] = (string)$this->getErrorMessage();
         }
 

--- a/src/OpenConext/UserLifecycle/Domain/Client/InformationResponseCollection.php
+++ b/src/OpenConext/UserLifecycle/Domain/Client/InformationResponseCollection.php
@@ -18,14 +18,11 @@
 
 namespace OpenConext\UserLifecycle\Domain\Client;
 
-use InvalidArgumentException;
-use JsonSerializable;
 use OpenConext\UserLifecycle\Domain\Exception\InformationResponseNotFoundException;
 use OpenConext\UserLifecycle\Domain\ValueObject\Client\Data;
 use OpenConext\UserLifecycle\Domain\ValueObject\Client\ErrorMessage;
 use OpenConext\UserLifecycle\Domain\ValueObject\Client\Name;
 use OpenConext\UserLifecycle\Domain\ValueObject\Client\ResponseStatus;
-use Webmozart\Assert\Assert;
 
 /**
  * A collection of InformationResponse objects

--- a/src/OpenConext/UserLifecycle/Domain/Client/InformationResponseCollectionInterface.php
+++ b/src/OpenConext/UserLifecycle/Domain/Client/InformationResponseCollectionInterface.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * Copyright 2018 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenConext\UserLifecycle\Domain\Client;
+
+use JsonSerializable;
+use OpenConext\UserLifecycle\Domain\ValueObject\Client\Data;
+use OpenConext\UserLifecycle\Domain\ValueObject\Client\ErrorMessage;
+use OpenConext\UserLifecycle\Domain\ValueObject\Client\Name;
+use OpenConext\UserLifecycle\Domain\ValueObject\Client\ResponseStatus;
+
+interface InformationResponseCollectionInterface extends JsonSerializable
+{
+    /**
+     * @param InformationResponseInterface $informationResponse
+     */
+    public function addInformationResponse(InformationResponseInterface $informationResponse);
+
+    /**
+     * @return InformationResponseInterface[]
+     */
+    public function getInformationResponses();
+
+    /**
+     * @return ErrorMessage[]
+     */
+    public function getErrorMessages();
+
+    /**
+     * @return string
+     */
+    public function jsonSerialize();
+}

--- a/src/OpenConext/UserLifecycle/Domain/Client/InformationResponseFactoryInterface.php
+++ b/src/OpenConext/UserLifecycle/Domain/Client/InformationResponseFactoryInterface.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * Copyright 2018 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenConext\UserLifecycle\Domain\Client;
+
+use InvalidArgumentException;
+use OpenConext\UserLifecycle\Domain\ValueObject\Client\Data;
+use OpenConext\UserLifecycle\Domain\ValueObject\Client\ErrorMessage;
+use OpenConext\UserLifecycle\Domain\ValueObject\Client\Name;
+use OpenConext\UserLifecycle\Domain\ValueObject\Client\ResponseStatus;
+use Webmozart\Assert\Assert;
+
+interface InformationResponseFactoryInterface
+{
+    public function fromApiResponse(array $response);
+}

--- a/src/OpenConext/UserLifecycle/Domain/Client/InformationResponseFactoryInterface.php
+++ b/src/OpenConext/UserLifecycle/Domain/Client/InformationResponseFactoryInterface.php
@@ -18,13 +18,6 @@
 
 namespace OpenConext\UserLifecycle\Domain\Client;
 
-use InvalidArgumentException;
-use OpenConext\UserLifecycle\Domain\ValueObject\Client\Data;
-use OpenConext\UserLifecycle\Domain\ValueObject\Client\ErrorMessage;
-use OpenConext\UserLifecycle\Domain\ValueObject\Client\Name;
-use OpenConext\UserLifecycle\Domain\ValueObject\Client\ResponseStatus;
-use Webmozart\Assert\Assert;
-
 interface InformationResponseFactoryInterface
 {
     public function fromApiResponse(array $response);

--- a/src/OpenConext/UserLifecycle/Domain/Client/InformationResponseInterface.php
+++ b/src/OpenConext/UserLifecycle/Domain/Client/InformationResponseInterface.php
@@ -1,0 +1,53 @@
+<?php
+
+/**
+ * Copyright 2018 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenConext\UserLifecycle\Domain\Client;
+
+use JsonSerializable;
+use OpenConext\UserLifecycle\Domain\ValueObject\Client\Data;
+use OpenConext\UserLifecycle\Domain\ValueObject\Client\ErrorMessage;
+use OpenConext\UserLifecycle\Domain\ValueObject\Client\Name;
+use OpenConext\UserLifecycle\Domain\ValueObject\Client\ResponseStatus;
+
+interface InformationResponseInterface extends JsonSerializable
+{
+    /**
+     * @return ResponseStatus
+     */
+    public function getStatus();
+
+    /**
+     * @return Name
+     */
+    public function getName();
+
+    /**
+     * @return Data
+     */
+    public function getData();
+
+    /**
+     * @return ErrorMessage
+     */
+    public function getErrorMessage();
+
+    /**
+     * @return string
+     */
+    public function jsonSerialize();
+}

--- a/src/OpenConext/UserLifecycle/Domain/Exception/InformationResponseNotFoundException.php
+++ b/src/OpenConext/UserLifecycle/Domain/Exception/InformationResponseNotFoundException.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * Copyright 2018 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenConext\UserLifecycle\Domain\Exception;
+
+use InvalidArgumentException;
+
+class InformationResponseNotFoundException extends InvalidArgumentException
+{
+
+}

--- a/src/OpenConext/UserLifecycle/Domain/Exception/InvalidCollabPersonIdException.php
+++ b/src/OpenConext/UserLifecycle/Domain/Exception/InvalidCollabPersonIdException.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * Copyright 2018 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenConext\UserLifecycle\Domain\Exception;
+
+use InvalidArgumentException;
+
+class InvalidCollabPersonIdException extends InvalidArgumentException
+{
+
+}

--- a/src/OpenConext/UserLifecycle/Domain/Exception/InvalidDataException.php
+++ b/src/OpenConext/UserLifecycle/Domain/Exception/InvalidDataException.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * Copyright 2018 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenConext\UserLifecycle\Domain\Exception;
+
+use InvalidArgumentException;
+
+class InvalidDataException extends InvalidArgumentException
+{
+
+}

--- a/src/OpenConext/UserLifecycle/Domain/Exception/InvalidNameException.php
+++ b/src/OpenConext/UserLifecycle/Domain/Exception/InvalidNameException.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * Copyright 2018 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenConext\UserLifecycle\Domain\Exception;
+
+use InvalidArgumentException;
+
+class InvalidNameException extends InvalidArgumentException
+{
+
+}

--- a/src/OpenConext/UserLifecycle/Domain/Exception/InvalidResponseStatusException.php
+++ b/src/OpenConext/UserLifecycle/Domain/Exception/InvalidResponseStatusException.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * Copyright 2018 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenConext\UserLifecycle\Domain\Exception;
+
+use InvalidArgumentException;
+
+class InvalidResponseStatusException extends InvalidArgumentException
+{
+
+}

--- a/src/OpenConext/UserLifecycle/Domain/Service/InformationServiceInterface.php
+++ b/src/OpenConext/UserLifecycle/Domain/Service/InformationServiceInterface.php
@@ -18,7 +18,7 @@
 
 namespace OpenConext\UserLifecycle\Domain\Service;
 
-interface LastLoginServiceInterface
+interface InformationServiceInterface
 {
     /**
      * @param string $personId

--- a/src/OpenConext/UserLifecycle/Domain/ValueObject/Client/Data.php
+++ b/src/OpenConext/UserLifecycle/Domain/ValueObject/Client/Data.php
@@ -18,6 +18,8 @@
 
 namespace OpenConext\UserLifecycle\Domain\ValueObject\Client;
 
+use InvalidArgumentException;
+use OpenConext\UserLifecycle\Domain\Client\InformationResponseInterface;
 use Webmozart\Assert\Assert;
 
 class Data
@@ -37,16 +39,50 @@ class Data
     {
         if (!empty($data)) {
             foreach ($data as $entry) {
-                Assert::isArray($entry);
-                Assert::allOneOf(array_keys($entry), [self::VALID_DATA_FIELD_NAME, self::VALID_DATA_FIELD_VALUE]);
+                $this->isValidEntry($entry);
             }
         }
 
         $this->data = $data;
     }
 
+    public static function buildEmpty()
+    {
+        $instance = new self([[self::VALID_DATA_FIELD_NAME => '', self::VALID_DATA_FIELD_VALUE => '']]);
+        $instance->data = [];
+
+        return $instance;
+    }
+
     public function getData()
     {
         return $this->data;
+    }
+
+    public function addDataEntry(array $entry)
+    {
+        $this->isValidEntry($entry);
+        $this->data[] = $entry;
+    }
+
+    public function addInformationResponse($name, InformationResponseInterface $informationResponse)
+    {
+        $entry = [
+            self::VALID_DATA_FIELD_NAME => $name,
+            self::VALID_DATA_FIELD_VALUE => $informationResponse,
+        ];
+
+        $this->addDataEntry($entry);
+    }
+
+    /**
+     * Tests if the entry is valid. If not an exception is thrown.
+     * @param $entry
+     * @throws InvalidArgumentException
+     */
+    private function isValidEntry($entry)
+    {
+        Assert::isArray($entry);
+        Assert::allOneOf(array_keys($entry), [self::VALID_DATA_FIELD_NAME, self::VALID_DATA_FIELD_VALUE]);
     }
 }

--- a/src/OpenConext/UserLifecycle/Domain/ValueObject/Client/Data.php
+++ b/src/OpenConext/UserLifecycle/Domain/ValueObject/Client/Data.php
@@ -18,9 +18,8 @@
 
 namespace OpenConext\UserLifecycle\Domain\ValueObject\Client;
 
-use InvalidArgumentException;
 use OpenConext\UserLifecycle\Domain\Client\InformationResponseInterface;
-use Webmozart\Assert\Assert;
+use OpenConext\UserLifecycle\Domain\Exception\InvalidDataException;
 
 class Data
 {
@@ -39,7 +38,7 @@ class Data
     {
         if (!empty($data)) {
             foreach ($data as $entry) {
-                $this->isValidEntry($entry);
+                $this->assertValidEntry($entry);
             }
         }
 
@@ -61,7 +60,7 @@ class Data
 
     public function addDataEntry(array $entry)
     {
-        $this->isValidEntry($entry);
+        $this->assertValidEntry($entry);
         $this->data[] = $entry;
     }
 
@@ -78,11 +77,17 @@ class Data
     /**
      * Tests if the entry is valid. If not an exception is thrown.
      * @param $entry
-     * @throws InvalidArgumentException
+     * @throws InvalidDataException
      */
-    private function isValidEntry($entry)
+    private function assertValidEntry($entry)
     {
-        Assert::isArray($entry);
-        Assert::allOneOf(array_keys($entry), [self::VALID_DATA_FIELD_NAME, self::VALID_DATA_FIELD_VALUE]);
+        if (!is_array($entry)) {
+            throw new InvalidDataException('The data must be of the type array');
+        }
+        if (!array_key_exists(self::VALID_DATA_FIELD_NAME, $entry) ||
+            !array_key_exists(self::VALID_DATA_FIELD_VALUE, $entry)
+        ) {
+            throw new InvalidDataException('Expected one of: "name", "value"');
+        }
     }
 }

--- a/src/OpenConext/UserLifecycle/Domain/ValueObject/Client/ErrorMessage.php
+++ b/src/OpenConext/UserLifecycle/Domain/ValueObject/Client/ErrorMessage.php
@@ -18,8 +18,6 @@
 
 namespace OpenConext\UserLifecycle\Domain\ValueObject\Client;
 
-use Webmozart\Assert\Assert;
-
 class ErrorMessage
 {
     /**
@@ -30,28 +28,9 @@ class ErrorMessage
     /**
      * @param string $errorMessage
      */
-    private function __construct($errorMessage = null)
+    public function __construct($errorMessage = null)
     {
         $this->errorMessage = $errorMessage;
-    }
-
-    public static function fromResponse(array $response, ResponseStatus $status)
-    {
-        // If status failed, we need an error message
-        if ($status->getStatus() === ResponseStatus::STATUS_FAILED) {
-            Assert::notEmpty($response['message']);
-        }
-
-        // If status OK, we do not want an error message
-        if ($status->getStatus() === ResponseStatus::STATUS_OK && isset($response['message'])) {
-            Assert::nullOrIsEmpty($response['message']);
-        }
-
-        if (isset($response['message']) && !empty($response['message'])) {
-            return new self($response['message']);
-        }
-        // If the message is not set, return an empty error message object
-        return new self();
     }
 
     public function hasErrorMessage()

--- a/src/OpenConext/UserLifecycle/Domain/ValueObject/Client/Name.php
+++ b/src/OpenConext/UserLifecycle/Domain/ValueObject/Client/Name.php
@@ -18,7 +18,7 @@
 
 namespace OpenConext\UserLifecycle\Domain\ValueObject\Client;
 
-use Webmozart\Assert\Assert;
+use OpenConext\UserLifecycle\Domain\Exception\InvalidNameException;
 
 class Name
 {
@@ -32,7 +32,9 @@ class Name
      */
     public function __construct($name)
     {
-        Assert::stringNotEmpty($name);
+        if (!is_string($name) || empty(trim($name))) {
+            throw new InvalidNameException('Name must be of the type string, and can not be empty.');
+        }
         $this->name = $name;
     }
 

--- a/src/OpenConext/UserLifecycle/Domain/ValueObject/Client/ResponseStatus.php
+++ b/src/OpenConext/UserLifecycle/Domain/ValueObject/Client/ResponseStatus.php
@@ -18,7 +18,7 @@
 
 namespace OpenConext\UserLifecycle\Domain\ValueObject\Client;
 
-use Webmozart\Assert\Assert;
+use OpenConext\UserLifecycle\Domain\Exception\InvalidResponseStatusException;
 
 class ResponseStatus
 {
@@ -35,8 +35,14 @@ class ResponseStatus
      */
     public function __construct($status)
     {
-        Assert::stringNotEmpty($status);
-        Assert::oneOf($status, [ResponseStatus::STATUS_FAILED, ResponseStatus::STATUS_OK]);
+        if (!is_string($status) || empty(trim($status))) {
+            throw new InvalidResponseStatusException('ResponseStatus must be of the type string, and can not be empty.');
+        }
+        $validStatuses = [ResponseStatus::STATUS_FAILED, ResponseStatus::STATUS_OK];
+
+        if (!in_array($status, $validStatuses)) {
+            throw new InvalidResponseStatusException('The ResponseStatus must be either "OK" or "FAILED".');
+        }
 
         $this->status = $status;
     }

--- a/src/OpenConext/UserLifecycle/Domain/ValueObject/CollabPersonId.php
+++ b/src/OpenConext/UserLifecycle/Domain/ValueObject/CollabPersonId.php
@@ -18,7 +18,7 @@
 
 namespace OpenConext\UserLifecycle\Domain\ValueObject;
 
-use Webmozart\Assert\Assert;
+use OpenConext\UserLifecycle\Domain\Exception\InvalidCollabPersonIdException;
 
 class CollabPersonId
 {
@@ -32,7 +32,10 @@ class CollabPersonId
         if (is_string($collabUserId)) {
             $collabUserId = trim($collabUserId);
         }
-        Assert::stringNotEmpty($collabUserId, 'The collabUserId must be a non empty string');
+        if (empty($collabUserId) || !is_string($collabUserId)) {
+            throw new InvalidCollabPersonIdException('The collabUserId must be a non empty string');
+        }
+
         $this->collabPersonId = $collabUserId;
     }
 

--- a/src/OpenConext/UserLifecycle/Infrastructure/UserLifecycleBundle/Client/DeprovisionClient.php
+++ b/src/OpenConext/UserLifecycle/Infrastructure/UserLifecycleBundle/Client/DeprovisionClient.php
@@ -22,7 +22,7 @@ use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Exception\GuzzleException;
 use InvalidArgumentException as CoreInvalidArgumentException;
 use OpenConext\UserLifecycle\Domain\Client\DeprovisionClientInterface;
-use OpenConext\UserLifecycle\Domain\Client\InformationResponse;
+use OpenConext\UserLifecycle\Domain\Client\InformationResponseFactoryInterface;
 use OpenConext\UserLifecycle\Domain\Client\InformationResponseInterface;
 use OpenConext\UserLifecycle\Domain\ValueObject\CollabPersonId;
 use OpenConext\UserLifecycle\Infrastructure\UserLifecycleBundle\Exception\InvalidArgumentException;
@@ -42,20 +42,27 @@ class DeprovisionClient implements DeprovisionClientInterface
     private $httpClient;
 
     /**
+     * @var InformationResponseFactoryInterface
+     */
+    private $informationResponseFactory;
+
+    /**
      * @var string
      */
     private $name;
 
     /**
      * @param ClientInterface $httpClient
+     * @param InformationResponseFactoryInterface $factory
      * @param string $name
      */
-    public function __construct(ClientInterface $httpClient, $name)
+    public function __construct(ClientInterface $httpClient, InformationResponseFactoryInterface $factory, $name)
     {
         Assert::string($name);
         $this->name = $name;
 
         $this->httpClient = $httpClient;
+        $this->informationResponseFactory = $factory;
     }
 
     public function deprovision(CollabPersonId $user, $dryRun = false)
@@ -184,7 +191,7 @@ class DeprovisionClient implements DeprovisionClientInterface
         }
 
         try {
-            $response = InformationResponse::fromApiResponse($data);
+            $response = $this->informationResponseFactory->fromApiResponse($data);
         } catch (CoreInvalidArgumentException $e) {
             throw new InvalidArgumentException(
                 sprintf(

--- a/src/OpenConext/UserLifecycle/Infrastructure/UserLifecycleBundle/Client/DeprovisionClient.php
+++ b/src/OpenConext/UserLifecycle/Infrastructure/UserLifecycleBundle/Client/DeprovisionClient.php
@@ -23,6 +23,7 @@ use GuzzleHttp\Exception\GuzzleException;
 use InvalidArgumentException as CoreInvalidArgumentException;
 use OpenConext\UserLifecycle\Domain\Client\DeprovisionClientInterface;
 use OpenConext\UserLifecycle\Domain\Client\InformationResponse;
+use OpenConext\UserLifecycle\Domain\Client\InformationResponseInterface;
 use OpenConext\UserLifecycle\Domain\ValueObject\CollabPersonId;
 use OpenConext\UserLifecycle\Infrastructure\UserLifecycleBundle\Exception\InvalidArgumentException;
 use OpenConext\UserLifecycle\Infrastructure\UserLifecycleBundle\Exception\InvalidResponseException;
@@ -64,7 +65,7 @@ class DeprovisionClient implements DeprovisionClientInterface
     /**
      * @param CollabPersonId $user
      *
-     * @return InformationResponse
+     * @return InformationResponseInterface
      *
      * @throws GuzzleException
      * @throws InvalidArgumentException
@@ -111,7 +112,7 @@ class DeprovisionClient implements DeprovisionClientInterface
      *               will be URL encoded and formatted into the path string.
      *               Example: "information/%s"
      * @param array $parameters
-     * @return InformationResponse $data
+     * @return InformationResponseInterface $data
      * @throws InvalidResponseException
      * @throws MalformedResponseException
      * @throws ResourceNotFoundException
@@ -155,7 +156,7 @@ class DeprovisionClient implements DeprovisionClientInterface
      * without config options as they are not needed.
      *
      * @param string $json
-     * @return InformationResponse
+     * @return InformationResponseInterface
      * @throws InvalidArgumentException
      */
     private function parseJson($json)

--- a/src/OpenConext/UserLifecycle/Infrastructure/UserLifecycleBundle/Client/DeprovisionClient.php
+++ b/src/OpenConext/UserLifecycle/Infrastructure/UserLifecycleBundle/Client/DeprovisionClient.php
@@ -111,7 +111,7 @@ class DeprovisionClient implements DeprovisionClientInterface
      *               will be URL encoded and formatted into the path string.
      *               Example: "information/%s"
      * @param array $parameters
-     * @return mixed $data
+     * @return InformationResponse $data
      * @throws InvalidResponseException
      * @throws MalformedResponseException
      * @throws ResourceNotFoundException
@@ -155,7 +155,7 @@ class DeprovisionClient implements DeprovisionClientInterface
      * without config options as they are not needed.
      *
      * @param string $json
-     * @return mixed
+     * @return InformationResponse
      * @throws InvalidArgumentException
      */
     private function parseJson($json)

--- a/src/OpenConext/UserLifecycle/Infrastructure/UserLifecycleBundle/Client/DeprovisionClientCollection.php
+++ b/src/OpenConext/UserLifecycle/Infrastructure/UserLifecycleBundle/Client/DeprovisionClientCollection.php
@@ -20,6 +20,7 @@ namespace OpenConext\UserLifecycle\Infrastructure\UserLifecycleBundle\Client;
 
 use OpenConext\UserLifecycle\Domain\Client\DeprovisionClientCollectionInterface;
 use OpenConext\UserLifecycle\Domain\Client\DeprovisionClientInterface;
+use OpenConext\UserLifecycle\Domain\Client\InformationResponseCollection;
 use OpenConext\UserLifecycle\Domain\ValueObject\CollabPersonId;
 
 class DeprovisionClientCollection implements DeprovisionClientCollectionInterface
@@ -38,12 +39,12 @@ class DeprovisionClientCollection implements DeprovisionClientCollectionInterfac
 
     public function information(CollabPersonId $user)
     {
-        $output = [];
+        $collection = new InformationResponseCollection();
         foreach ($this->clients as $client) {
-            $output[] = $client->information($user);
+            $collection->addInformationResponse($client->information($user));
         }
 
-        return json_encode($output, JSON_PRETTY_PRINT);
+        return $collection;
     }
 
     public function getName()

--- a/src/OpenConext/UserLifecycle/Infrastructure/UserLifecycleBundle/Client/DeprovisionClientCollection.php
+++ b/src/OpenConext/UserLifecycle/Infrastructure/UserLifecycleBundle/Client/DeprovisionClientCollection.php
@@ -47,11 +47,6 @@ class DeprovisionClientCollection implements DeprovisionClientCollectionInterfac
         return $collection;
     }
 
-    public function getName()
-    {
-        return 'DeprovisionClientCollection';
-    }
-
     public function addClient(DeprovisionClientInterface $client)
     {
         $this->clients[$client->getName()] = $client;

--- a/src/OpenConext/UserLifecycle/Infrastructure/UserLifecycleBundle/Command/InformationCommand.php
+++ b/src/OpenConext/UserLifecycle/Infrastructure/UserLifecycleBundle/Command/InformationCommand.php
@@ -19,7 +19,8 @@
 namespace OpenConext\UserLifecycle\Infrastructure\UserLifecycleBundle\Command;
 
 use InvalidArgumentException;
-use OpenConext\UserLifecycle\Domain\Service\LastLoginServiceInterface;
+use OpenConext\UserLifecycle\Application\Service\InformationService;
+use OpenConext\UserLifecycle\Domain\Service\InformationServiceInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -34,14 +35,15 @@ class InformationCommand extends Command
     private $logger;
 
     /**
-     * @var LastLoginServiceInterface
+     * @var InformationService
      */
     private $service;
 
-    public function __construct(LastLoginServiceInterface $lastLoginService, LoggerInterface $logger)
+
+    public function __construct(InformationServiceInterface $informationService, LoggerInterface $logger)
     {
         parent::__construct(null);
-        $this->service = $lastLoginService;
+        $this->service = $informationService;
         $this->logger = $logger;
     }
 

--- a/src/OpenConext/UserLifecycle/Infrastructure/UserLifecycleBundle/DependencyInjection/UserLifecycleExtension.php
+++ b/src/OpenConext/UserLifecycle/Infrastructure/UserLifecycleBundle/DependencyInjection/UserLifecycleExtension.php
@@ -19,6 +19,7 @@
 namespace OpenConext\UserLifecycle\Infrastructure\UserLifecycleBundle\DependencyInjection;
 
 use GuzzleHttp\Client;
+use OpenConext\UserLifecycle\Application\Client\InformationResponseFactory;
 use OpenConext\UserLifecycle\Infrastructure\UserLifecycleBundle\Client\DeprovisionClient;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -59,11 +60,16 @@ class UserLifecycleExtension extends Extension
             $definition->addTag('open_conext.user_lifecycle.deprovision_client');
             $guzzleDefinition = $this->buildGuzzleClientDefinition($clientConfiguration, $clientName, $container);
 
+            $factoryDefinition = new Definition(InformationResponseFactory::class);
+
             // Set the guzzle client on the DeprovisionClient
             $definition->setArgument(0, $guzzleDefinition);
 
+            // Set the information response factory on the DeprovisionClient
+            $definition->setArgument(1, $factoryDefinition);
+
             // Set the client name on the DeprovisionClient
-            $definition->setArgument(1, $clientName);
+            $definition->setArgument(2, $clientName);
 
             $container->setDefinition(
                 sprintf("open_conext.user_lifecycle.deprovision_client.%s", $clientName),

--- a/src/OpenConext/UserLifecycle/Infrastructure/UserLifecycleBundle/Resources/config/services.yml
+++ b/src/OpenConext/UserLifecycle/Infrastructure/UserLifecycleBundle/Resources/config/services.yml
@@ -12,7 +12,7 @@ services:
 
     OpenConext\UserLifecycle\Infrastructure\UserLifecycleBundle\Command\InformationCommand:
         arguments:
-            - '@OpenConext\UserLifecycle\Application\Service\LastLoginService'
+            - '@OpenConext\UserLifecycle\Application\Service\InformationService'
             - '@logger'
         tags:
             - 'console.command'

--- a/src/OpenConext/UserLifecycle/Infrastructure/UserLifecycleBundle/Resources/config/services.yml
+++ b/src/OpenConext/UserLifecycle/Infrastructure/UserLifecycleBundle/Resources/config/services.yml
@@ -23,5 +23,7 @@ services:
         arguments:
             - OpenConext\UserLifecycle\Domain\Entity\LastLogin
 
+    OpenConext\UserLifecycle\Domain\Client\InformationResponseFactoryInterface: '@OpenConext\UserLifecycle\Application\Client\InformationResponseFactory'
+
     open_conext.user_lifecycle.deprovision_client_collection:
         class: OpenConext\UserLifecycle\Infrastructure\UserLifecycleBundle\Client\DeprovisionClientCollection

--- a/tests/integration/UserLifecycleBundle/Command/InformationCommandTest.php
+++ b/tests/integration/UserLifecycleBundle/Command/InformationCommandTest.php
@@ -21,7 +21,7 @@ namespace OpenConext\UserLifecycle\Tests\Integration\UserLifecycleBundle\Command
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\Psr7\Response;
 use Mockery as m;
-use OpenConext\UserLifecycle\Application\Service\LastLoginService;
+use OpenConext\UserLifecycle\Application\Service\InformationService;
 use OpenConext\UserLifecycle\Infrastructure\UserLifecycleBundle\Command\InformationCommand;
 use OpenConext\UserLifecycle\Tests\Integration\DatabaseTestCase;
 use Psr\Container\ContainerInterface;
@@ -78,7 +78,7 @@ class LastLoginRepositoryTest extends DatabaseTestCase
         // Create the application and add the information command
         $this->application = new Application(self::$kernel);
 
-        $lastLoginService = self::$kernel->getContainer()->get(LastLoginService::class);
+        $lastLoginService = self::$kernel->getContainer()->get(InformationService::class);
 
         $logger = m::mock(LoggerInterface::class);
         $logger->shouldIgnoreMissing();

--- a/tests/integration/UserLifecycleBundle/Resources/config/services.yml
+++ b/tests/integration/UserLifecycleBundle/Resources/config/services.yml
@@ -4,9 +4,9 @@ services:
         public: true
         class: OpenConext\UserLifecycle\Infrastructure\UserLifecycleBundle\Client\DeprovisionClientCollection
 
-    OpenConext\UserLifecycle\Application\Service\LastLoginService:
+    OpenConext\UserLifecycle\Application\Service\InformationService:
         public: true
-        class: OpenConext\UserLifecycle\Application\Service\LastLoginService
+        class: OpenConext\UserLifecycle\Application\Service\InformationService
         arguments:
             - '@open_conext.user_lifecycle.test.deprovision_client_collection'
             - '@logger'

--- a/tests/integration/UserLifecycleBundle/Resources/config/services.yml
+++ b/tests/integration/UserLifecycleBundle/Resources/config/services.yml
@@ -16,6 +16,7 @@ services:
         public: true
         arguments:
             - '@open_conext.user_lifecycle.guzzle_client.my_service_name'
+            - '@OpenConext\UserLifecycle\Application\Client\InformationResponseFactory'
             - 'my_service_name'
 
     open_conext.user_lifecycle.deprovision_client.test.my_second_name:
@@ -23,6 +24,7 @@ services:
         public: true
         arguments:
             - '@open_conext.user_lifecycle.guzzle_client.my_second_name'
+            - '@OpenConext\UserLifecycle\Application\Client\InformationResponseFactory'
             - 'my_second_name'
 
     open_conext.user_lifecycle.guzzle_mock_handler.my_service_name:

--- a/tests/unit/Application/Client/InformationResponseFactoryTest.php
+++ b/tests/unit/Application/Client/InformationResponseFactoryTest.php
@@ -19,16 +19,24 @@
 namespace OpenConext\UserLifecycle\Tests\Unit\Domain\ValueObject;
 
 use InvalidArgumentException;
+use OpenConext\UserLifecycle\Application\Client\InformationResponseFactory;
 use OpenConext\UserLifecycle\Domain\Client\InformationResponse;
 use OpenConext\UserLifecycle\Domain\ValueObject\Client\ResponseStatus;
 use PHPUnit\Framework\TestCase;
 
-class InformationResponseTest extends TestCase
+class InformationResponseFactoryTest extends TestCase
 {
+    private $informationResponseFactory;
+
+    public function setUp()
+    {
+        $this->informationResponseFactory = new InformationResponseFactory();
+    }
+
     public function test_build_from_ok_api_response()
     {
         $data = [['name' => 'fieldname', 'value' => 'fieldvalue']];
-        $response = InformationResponse::fromApiResponse(
+        $response = $this->informationResponseFactory->fromApiResponse(
             $this->buildResponse(
                 'my-service-name',
                 'OK',
@@ -45,7 +53,7 @@ class InformationResponseTest extends TestCase
 
     public function test_build_from_failed_api_response()
     {
-        $response = InformationResponse::fromApiResponse(
+        $response = $this->informationResponseFactory->fromApiResponse(
             $this->buildResponse(
                 'my-service-name',
                 'FAILED',
@@ -70,7 +78,7 @@ class InformationResponseTest extends TestCase
             ]
         ]];
 
-        $response = InformationResponse::fromApiResponse(
+        $response = $this->informationResponseFactory->fromApiResponse(
             $this->buildResponse(
                 'my-service-name',
                 'OK',
@@ -91,7 +99,7 @@ class InformationResponseTest extends TestCase
     public function test_fails_on_invalid_response($invalidResponse)
     {
         $this->expectException(InvalidArgumentException::class);
-        InformationResponse::fromApiResponse($invalidResponse);
+        $this->informationResponseFactory->fromApiResponse($invalidResponse);
     }
 
     public function buildInvalidResponses()

--- a/tests/unit/Application/Service/LastLoginServiceTest.php
+++ b/tests/unit/Application/Service/LastLoginServiceTest.php
@@ -22,7 +22,7 @@ use InvalidArgumentException;
 use Mockery as m;
 use Mockery\Mock;
 use OpenConext\UserLifecycle\Application\QueryHandler\LastLoginByUserIdQueryHandlerInterface;
-use OpenConext\UserLifecycle\Application\Service\LastLoginService;
+use OpenConext\UserLifecycle\Application\Service\InformationService;
 use OpenConext\UserLifecycle\Domain\Client\DeprovisionClientCollectionInterface;
 use OpenConext\UserLifecycle\Domain\Entity\LastLogin;
 use PHPUnit\Framework\TestCase;
@@ -31,7 +31,7 @@ use Psr\Log\LoggerInterface;
 class LastLoginServiceTest extends TestCase
 {
     /**
-     * @var LastLoginService
+     * @var InformationService
      */
     private $service;
 
@@ -49,7 +49,7 @@ class LastLoginServiceTest extends TestCase
     {
         $this->apiCollection = m::mock(DeprovisionClientCollectionInterface::class);
         $logger = m::mock(LoggerInterface::class)->shouldIgnoreMissing();
-        $this->service = new LastLoginService($this->apiCollection, $logger);
+        $this->service = new InformationService($this->apiCollection, $logger);
     }
 
     public function test_read_information_for()

--- a/tests/unit/Application/Service/LastLoginServiceTest.php
+++ b/tests/unit/Application/Service/LastLoginServiceTest.php
@@ -24,6 +24,7 @@ use Mockery\Mock;
 use OpenConext\UserLifecycle\Application\QueryHandler\LastLoginByUserIdQueryHandlerInterface;
 use OpenConext\UserLifecycle\Application\Service\InformationService;
 use OpenConext\UserLifecycle\Domain\Client\DeprovisionClientCollectionInterface;
+use OpenConext\UserLifecycle\Domain\Client\InformationResponseCollection;
 use OpenConext\UserLifecycle\Domain\Entity\LastLogin;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
@@ -34,11 +35,6 @@ class LastLoginServiceTest extends TestCase
      * @var InformationService
      */
     private $service;
-
-    /**
-     * @var LastLoginByUserIdQueryHandlerInterface|Mock
-     */
-    private $queryHandler;
 
     /**
      * @var DeprovisionClientCollectionInterface|Mock
@@ -57,11 +53,14 @@ class LastLoginServiceTest extends TestCase
         // Setup the test using test doubles
         $personId = 'jay-leno';
 
-        $lastLogin = m::mock(LastLogin::class)->makePartial();
+        $collection = m::mock(InformationResponseCollection::class);
+        $collection
+            ->shouldReceive('jsonSerialize')
+            ->andReturn('{"only": "test"}');
 
         $this->apiCollection
             ->shouldReceive('information')
-            ->andReturn('{"status": "OK"}');
+            ->andReturn($collection);
 
         // Call the readInformationFor method
         $response = $this->service->readInformationFor($personId);

--- a/tests/unit/Domain/Client/InformationResponseCollectionTest.php
+++ b/tests/unit/Domain/Client/InformationResponseCollectionTest.php
@@ -32,10 +32,8 @@ class InformationResponseCollectionTest extends TestCase
     public function test_can_be_created()
     {
         $collection = new InformationResponseCollection();
-        $this->assertEmpty($collection->getData()->getData());
-        $this->assertEquals(ResponseStatus::STATUS_OK, (string)$collection->getStatus());
-        $this->assertEquals('InformationResponseCollection', (string)$collection->getName());
-        $this->assertNull($collection->getErrorMessage());
+        $this->assertEmpty($collection->getInformationResponses());
+        $this->assertEmpty($collection->getErrorMessages());
     }
 
     public function test_can_be_set_with_information_responses()
@@ -47,10 +45,8 @@ class InformationResponseCollectionTest extends TestCase
         $collection->addInformationResponse($info1);
         $collection->addInformationResponse($info2);
 
-        $this->assertCount(2, $collection->getData()->getData());
-        $this->assertEquals(ResponseStatus::STATUS_OK, $collection->getStatus()->getStatus());
-        $this->assertEquals('InformationResponseCollection', $collection->getName()->getName());
-        $this->assertNull($collection->getErrorMessage());
+        $this->assertCount(2, $collection->getInformationResponses());
+        $this->assertEmpty($collection->getErrorMessages());
     }
 
     public function test_it_sets_last_error_message()
@@ -67,23 +63,11 @@ class InformationResponseCollectionTest extends TestCase
         $collection->addInformationResponse($info1);
         $collection->addInformationResponse($info2);
 
-        $this->assertCount(2, $collection->getData()->getData());
-        $this->assertEquals(ResponseStatus::STATUS_FAILED, $collection->getStatus()->getStatus());
-        $this->assertEquals('InformationResponseCollection', $collection->getName()->getName());
-        $this->assertEquals('Service unavailable', $collection->getErrorMessage()->getErrorMessage());
-    }
+        $this->assertCount(2, $collection->getInformationResponses());
+        $errorMessages = $collection->getErrorMessages();
 
-    public function test_an_information_response_can_be_retrieved_by_name_of_response()
-    {
-        $info1 = $this->buildMockInformationResponse('OK', 'engine', [['name' => 'user', 'value' => 'JK']]);
-        $info2 = $this->buildMockInformationResponse('OK', 'teams', [['name' => 'user', 'value' => 'JK']]);
-
-        $collection = new InformationResponseCollection();
-        $collection->addInformationResponse($info1);
-        $collection->addInformationResponse($info2);
-
-        $informationResponse = $collection->getByName('engine');
-        $this->assertEquals($informationResponse, $info1);
+        $this->assertArrayHasKey('teams', $errorMessages);
+        $this->assertEquals('Service unavailable', $errorMessages['teams']);
     }
 
     private function buildMockInformationResponse($status, $name, $data, $errorMessage = null)
@@ -115,6 +99,10 @@ class InformationResponseCollectionTest extends TestCase
         if ($errorMessage) {
             $errorMessageMock
                 ->shouldReceive('getErrorMessage')
+                ->andReturn($errorMessage);
+
+            $errorMessageMock
+                ->shouldReceive('__toString')
                 ->andReturn($errorMessage);
 
             $hasErrorMessage = true;

--- a/tests/unit/Domain/Client/InformationResponseCollectionTest.php
+++ b/tests/unit/Domain/Client/InformationResponseCollectionTest.php
@@ -1,0 +1,134 @@
+<?php
+
+/**
+ * Copyright 2018 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenConext\UserLifecycle\Tests\Unit\Domain\Client;
+
+use Mockery as m;
+use OpenConext\UserLifecycle\Domain\Client\InformationResponseCollection;
+use OpenConext\UserLifecycle\Domain\Client\InformationResponseInterface;
+use OpenConext\UserLifecycle\Domain\ValueObject\Client\Data;
+use OpenConext\UserLifecycle\Domain\ValueObject\Client\ErrorMessage;
+use OpenConext\UserLifecycle\Domain\ValueObject\Client\Name;
+use OpenConext\UserLifecycle\Domain\ValueObject\Client\ResponseStatus;
+use PHPUnit\Framework\TestCase;
+
+class InformationResponseCollectionTest extends TestCase
+{
+    public function test_can_be_created()
+    {
+        $collection = new InformationResponseCollection();
+        $this->assertEmpty($collection->getData()->getData());
+        $this->assertEquals(ResponseStatus::STATUS_OK, (string)$collection->getStatus());
+        $this->assertEquals('InformationResponseCollection', (string)$collection->getName());
+        $this->assertNull($collection->getErrorMessage());
+    }
+
+    public function test_can_be_set_with_information_responses()
+    {
+        $info1 = $this->buildMockInformationResponse('OK', 'engine', [['name' => 'user', 'value' => 'JK']]);
+        $info2 = $this->buildMockInformationResponse('OK', 'teams', [['name' => 'user', 'value' => 'JK']]);
+
+        $collection = new InformationResponseCollection();
+        $collection->addInformationResponse($info1);
+        $collection->addInformationResponse($info2);
+
+        $this->assertCount(2, $collection->getData()->getData());
+        $this->assertEquals(ResponseStatus::STATUS_OK, $collection->getStatus()->getStatus());
+        $this->assertEquals('InformationResponseCollection', $collection->getName()->getName());
+        $this->assertNull($collection->getErrorMessage());
+    }
+
+    public function test_it_sets_last_error_message()
+    {
+        $info1 = $this->buildMockInformationResponse(
+            'FAILED',
+            'teams',
+            [['name' => 'user', 'value' => 'JK']],
+            'Service unavailable'
+        );
+        $info2 = $this->buildMockInformationResponse('OK', 'engine', [['name' => 'user', 'value' => 'JK']]);
+
+        $collection = new InformationResponseCollection();
+        $collection->addInformationResponse($info1);
+        $collection->addInformationResponse($info2);
+
+        $this->assertCount(2, $collection->getData()->getData());
+        $this->assertEquals(ResponseStatus::STATUS_FAILED, $collection->getStatus()->getStatus());
+        $this->assertEquals('InformationResponseCollection', $collection->getName()->getName());
+        $this->assertEquals('Service unavailable', $collection->getErrorMessage()->getErrorMessage());
+    }
+
+    public function test_an_information_response_can_be_retrieved_by_name_of_response()
+    {
+        $info1 = $this->buildMockInformationResponse('OK', 'engine', [['name' => 'user', 'value' => 'JK']]);
+        $info2 = $this->buildMockInformationResponse('OK', 'teams', [['name' => 'user', 'value' => 'JK']]);
+
+        $collection = new InformationResponseCollection();
+        $collection->addInformationResponse($info1);
+        $collection->addInformationResponse($info2);
+
+        $informationResponse = $collection->getByName('engine');
+        $this->assertEquals($informationResponse, $info1);
+    }
+
+    private function buildMockInformationResponse($status, $name, $data, $errorMessage = null)
+    {
+        $informationResponse = m::mock(InformationResponseInterface::class);
+
+        $statusMock = m::mock(ResponseStatus::class);
+        $statusMock
+            ->shouldReceive('getStatus')
+            ->andReturn($status);
+
+        $nameMock = m::mock(Name::class);
+        $nameMock
+            ->shouldReceive('getName')
+            ->andReturn($name);
+        $nameMock
+            ->shouldReceive('__toString')
+            ->andReturn($name);
+
+        $dataMock = m::mock(Data::class);
+        $dataMock
+            ->shouldReceive('getData')
+            ->andReturn($data);
+
+
+        $errorMessageMock = m::mock(ErrorMessage::class);
+        $hasErrorMessage = false;
+
+        if ($errorMessage) {
+            $errorMessageMock
+                ->shouldReceive('getErrorMessage')
+                ->andReturn($errorMessage);
+
+            $hasErrorMessage = true;
+        }
+
+        $errorMessageMock
+            ->shouldReceive('hasErrorMessage')
+            ->andReturn($hasErrorMessage);
+
+        $informationResponse->shouldReceive('getStatus')->andReturn($statusMock);
+        $informationResponse->shouldReceive('getName')->andReturn($nameMock);
+        $informationResponse->shouldReceive('getData')->andReturn($dataMock);
+        $informationResponse->shouldReceive('getErrorMessage')->andReturn($errorMessageMock);
+
+        return $informationResponse;
+    }
+}

--- a/tests/unit/Domain/ValueObject/Client/DataTest.php
+++ b/tests/unit/Domain/ValueObject/Client/DataTest.php
@@ -1,0 +1,67 @@
+<?php
+
+/**
+ * Copyright 2018 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenConext\UserLifecycle\Tests\Unit\Domain\ValueObject\Client;
+
+use Mockery as m;
+use OpenConext\UserLifecycle\Domain\Client\InformationResponseInterface;
+use OpenConext\UserLifecycle\Domain\ValueObject\Client\Data;
+use PHPUnit\Framework\TestCase;
+
+class DataTest extends TestCase
+{
+    public function test_build_empty()
+    {
+        $data = Data::buildEmpty();
+        $this->assertEmpty($data->getData());
+    }
+
+    public function test_add_entry()
+    {
+        $data = Data::buildEmpty();
+        $entry = ['name' => 'collabPersonId', 'value' => 'urn:collab:person:jesse.james'];
+        $entryTeams = ['name' => 'teams', 'value' => 'admins'];
+        $data->addDataEntry($entry);
+        $data->addDataEntry($entryTeams);
+        $this->assertEquals([$entry, $entryTeams], $data->getData());
+    }
+
+    public function test_add_information_response()
+    {
+        $data = Data::buildEmpty();
+
+        $informationResponse = m::mock(InformationResponseInterface::class);
+
+        $data->addInformationResponse('foobar', $informationResponse);
+        $this->assertEquals([['name' => 'foobar', 'value' => $informationResponse]], $data->getData());
+    }
+
+    public function test_it_reject_invalid_data_expects_array_of_entries()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Expected an array. Got: string');
+        new Data(['name' => 'my name', 'value' => 'my value']);
+    }
+
+    public function test_it_reject_invalid_data_expects_valid_entries()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Expected one of: "name", "value". Got: "key"');
+        new Data([['key' => 'my name', 'value' => 'my value']]);
+    }
+}

--- a/tests/unit/Domain/ValueObject/Client/DataTest.php
+++ b/tests/unit/Domain/ValueObject/Client/DataTest.php
@@ -20,6 +20,7 @@ namespace OpenConext\UserLifecycle\Tests\Unit\Domain\ValueObject\Client;
 
 use Mockery as m;
 use OpenConext\UserLifecycle\Domain\Client\InformationResponseInterface;
+use OpenConext\UserLifecycle\Domain\Exception\InvalidDataException;
 use OpenConext\UserLifecycle\Domain\ValueObject\Client\Data;
 use PHPUnit\Framework\TestCase;
 
@@ -53,15 +54,15 @@ class DataTest extends TestCase
 
     public function test_it_reject_invalid_data_expects_array_of_entries()
     {
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('Expected an array. Got: string');
+        $this->expectException(InvalidDataException::class);
+        $this->expectExceptionMessage('The data must be of the type array');
         new Data(['name' => 'my name', 'value' => 'my value']);
     }
 
     public function test_it_reject_invalid_data_expects_valid_entries()
     {
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('Expected one of: "name", "value". Got: "key"');
+        $this->expectException(InvalidDataException::class);
+        $this->expectExceptionMessage('Expected one of: "name", "value"');
         new Data([['key' => 'my name', 'value' => 'my value']]);
     }
 }

--- a/tests/unit/Domain/ValueObject/CollabPersonIdTest.php
+++ b/tests/unit/Domain/ValueObject/CollabPersonIdTest.php
@@ -18,6 +18,7 @@
 
 namespace OpenConext\UserLifecycle\Tests\Unit\Domain\ValueObject;
 
+use OpenConext\UserLifecycle\Domain\Exception\InvalidCollabPersonIdException;
 use OpenConext\UserLifecycle\Domain\ValueObject\CollabPersonId;
 use PHPUnit\Framework\TestCase;
 
@@ -35,7 +36,7 @@ class CollabPersonIdTest extends TestCase
      */
     public function test_must_be_non_empty_string($invalidArgument)
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidCollabPersonIdException::class);
         $this->expectExceptionMessage('The collabUserId must be a non empty string');
 
         new CollabPersonId($invalidArgument);


### PR DESCRIPTION
In short, the DeprovisionClientCollection returned a JSON string when asked for user information, where the individual clients returned a fancy InformationResponse object. To remedy this problem, the composite pattern was applied to the information response. Splitting them into an information response and collection.

See commit messages for more details.