### PR TITLE
Remove unused methods form Data

### DIFF
--- a/src/OpenConext/UserLifecycle/Domain/ValueObject/Client/Data.php
+++ b/src/OpenConext/UserLifecycle/Domain/ValueObject/Client/Data.php
@@ -18,7 +18,6 @@
 
 namespace OpenConext\UserLifecycle\Domain\ValueObject\Client;
 
-use OpenConext\UserLifecycle\Domain\Client\InformationResponseInterface;
 use OpenConext\UserLifecycle\Domain\Exception\InvalidDataException;
 
 class Data
@@ -45,33 +44,9 @@ class Data
         $this->data = $data;
     }
 
-    public static function buildEmpty()
-    {
-        $instance = new self([[self::VALID_DATA_FIELD_NAME => '', self::VALID_DATA_FIELD_VALUE => '']]);
-        $instance->data = [];
-
-        return $instance;
-    }
-
     public function getData()
     {
         return $this->data;
-    }
-
-    public function addDataEntry(array $entry)
-    {
-        $this->assertValidEntry($entry);
-        $this->data[] = $entry;
-    }
-
-    public function addInformationResponse($name, InformationResponseInterface $informationResponse)
-    {
-        $entry = [
-            self::VALID_DATA_FIELD_NAME => $name,
-            self::VALID_DATA_FIELD_VALUE => $informationResponse,
-        ];
-
-        $this->addDataEntry($entry);
     }
 
     /**

--- a/tests/unit/Domain/ValueObject/Client/DataTest.php
+++ b/tests/unit/Domain/ValueObject/Client/DataTest.php
@@ -28,28 +28,16 @@ class DataTest extends TestCase
 {
     public function test_build_empty()
     {
-        $data = Data::buildEmpty();
+        $data = new Data([]);
         $this->assertEmpty($data->getData());
     }
 
     public function test_add_entry()
     {
-        $data = Data::buildEmpty();
         $entry = ['name' => 'collabPersonId', 'value' => 'urn:collab:person:jesse.james'];
         $entryTeams = ['name' => 'teams', 'value' => 'admins'];
-        $data->addDataEntry($entry);
-        $data->addDataEntry($entryTeams);
+        $data = new Data([$entry, $entryTeams]);
         $this->assertEquals([$entry, $entryTeams], $data->getData());
-    }
-
-    public function test_add_information_response()
-    {
-        $data = Data::buildEmpty();
-
-        $informationResponse = m::mock(InformationResponseInterface::class);
-
-        $data->addInformationResponse('foobar', $informationResponse);
-        $this->assertEquals([['name' => 'foobar', 'value' => $informationResponse]], $data->getData());
     }
 
     public function test_it_reject_invalid_data_expects_array_of_entries()


### PR DESCRIPTION
The add methods where not utilized and the create empty factory method
wasn't either. This commit removes those methods and updates the Data
test case.