### PR TITLE
Improve the output of the commands

### DIFF
--- a/src/OpenConext/UserLifecycle/Application/Service/DeprovisionService.php
+++ b/src/OpenConext/UserLifecycle/Application/Service/DeprovisionService.php
@@ -21,7 +21,9 @@ namespace OpenConext\UserLifecycle\Application\Service;
 use OpenConext\UserLifecycle\Application\Command\RemoveFromLastLoginCommand;
 use OpenConext\UserLifecycle\Application\CommandHandler\RemoveFromLastLoginCommandHandler;
 use OpenConext\UserLifecycle\Domain\Client\BatchInformationResponseCollection;
+use OpenConext\UserLifecycle\Domain\Client\BatchInformationResponseCollectionInterface;
 use OpenConext\UserLifecycle\Domain\Client\DeprovisionClientCollectionInterface;
+use OpenConext\UserLifecycle\Domain\Client\InformationResponseCollectionInterface;
 use OpenConext\UserLifecycle\Domain\Service\DeprovisionServiceInterface;
 use OpenConext\UserLifecycle\Domain\Service\LastLoginServiceInterface;
 use OpenConext\UserLifecycle\Domain\Service\RemovalCheckServiceInterface;
@@ -81,7 +83,7 @@ class DeprovisionService implements DeprovisionServiceInterface
     /**
      * @param string $personId
      * @param bool $dryRun
-     * @return string
+     * @return InformationResponseCollectionInterface
      */
     public function deprovision($personId, $dryRun = false)
     {
@@ -105,14 +107,14 @@ class DeprovisionService implements DeprovisionServiceInterface
             $this->removeFromLastLoginCommandHandler->handle($command);
         }
 
-        return json_encode($information->jsonSerialize());
+        return $information;
     }
 
     /**
      * Finds the users marked for deprovisioning, and deprovisions them.
      *
      * @param bool $dryRun
-     * @return string
+     * @return BatchInformationResponseCollectionInterface
      */
     public function batchDeprovision($dryRun = false)
     {
@@ -144,7 +146,7 @@ class DeprovisionService implements DeprovisionServiceInterface
             }
         }
 
-        return json_encode($batchInformationCollection->jsonSerialize());
+        return $batchInformationCollection;
     }
 
     private function buildCollabPersonId($personId)

--- a/src/OpenConext/UserLifecycle/Application/Service/DeprovisionService.php
+++ b/src/OpenConext/UserLifecycle/Application/Service/DeprovisionService.php
@@ -95,7 +95,7 @@ class DeprovisionService implements DeprovisionServiceInterface
 
         $this->logger->info(
             sprintf('Received deprovision information for user "%s" with the following data.', $personId),
-            ['information_response' => $information->jsonSerialize()]
+            ['information_response' => json_encode($information->jsonSerialize())]
         );
 
         if (!$dryRun && $this->removalCheckService->mayBeRemoved($information)) {
@@ -105,7 +105,7 @@ class DeprovisionService implements DeprovisionServiceInterface
             $this->removeFromLastLoginCommandHandler->handle($command);
         }
 
-        return $information->jsonSerialize();
+        return json_encode($information->jsonSerialize());
     }
 
     /**
@@ -133,7 +133,7 @@ class DeprovisionService implements DeprovisionServiceInterface
                     'Received deprovision information for user "%s" with the following data.',
                     $lastLogin->getCollabPersonId()
                 ),
-                ['information_response' => $information->jsonSerialize()]
+                ['information_response' => json_encode($information->jsonSerialize())]
             );
 
             if (!$dryRun && $this->removalCheckService->mayBeRemoved($information)) {
@@ -144,7 +144,7 @@ class DeprovisionService implements DeprovisionServiceInterface
             }
         }
 
-        return $batchInformationCollection->jsonSerialize();
+        return json_encode($batchInformationCollection->jsonSerialize());
     }
 
     private function buildCollabPersonId($personId)

--- a/src/OpenConext/UserLifecycle/Application/Service/DeprovisionService.php
+++ b/src/OpenConext/UserLifecycle/Application/Service/DeprovisionService.php
@@ -97,7 +97,7 @@ class DeprovisionService implements DeprovisionServiceInterface
 
         $this->logger->info(
             sprintf('Received deprovision information for user "%s" with the following data.', $personId),
-            ['information_response' => json_encode($information->jsonSerialize())]
+            ['information_response' => json_encode($information)]
         );
 
         if (!$dryRun && $this->removalCheckService->mayBeRemoved($information)) {
@@ -135,7 +135,7 @@ class DeprovisionService implements DeprovisionServiceInterface
                     'Received deprovision information for user "%s" with the following data.',
                     $lastLogin->getCollabPersonId()
                 ),
-                ['information_response' => json_encode($information->jsonSerialize())]
+                ['information_response' => json_encode($information)]
             );
 
             if (!$dryRun && $this->removalCheckService->mayBeRemoved($information)) {

--- a/src/OpenConext/UserLifecycle/Application/Service/InformationService.php
+++ b/src/OpenConext/UserLifecycle/Application/Service/InformationService.php
@@ -21,7 +21,6 @@ namespace OpenConext\UserLifecycle\Application\Service;
 use InvalidArgumentException;
 use OpenConext\UserLifecycle\Domain\Client\DeprovisionClientCollectionInterface;
 use OpenConext\UserLifecycle\Domain\Client\InformationResponseCollectionInterface;
-use OpenConext\UserLifecycle\Domain\Client\InformationResponseInterface;
 use OpenConext\UserLifecycle\Domain\Service\InformationServiceInterface;
 use OpenConext\UserLifecycle\Domain\ValueObject\CollabPersonId;
 use Psr\Log\LoggerInterface;

--- a/src/OpenConext/UserLifecycle/Application/Service/InformationService.php
+++ b/src/OpenConext/UserLifecycle/Application/Service/InformationService.php
@@ -60,7 +60,7 @@ class InformationService implements InformationServiceInterface
         $collabPersonId = new CollabPersonId($personId);
 
         $this->logger->debug('Retrieve the information from the APIs for the user.');
-        $information = $this->deprovisionClientCollection->information($collabPersonId)->jsonSerialize();
+        $information = json_encode($this->deprovisionClientCollection->information($collabPersonId)->jsonSerialize());
 
         $this->logger->info(
             sprintf('Received information for user "%s" with the following data.', $personId),

--- a/src/OpenConext/UserLifecycle/Application/Service/InformationService.php
+++ b/src/OpenConext/UserLifecycle/Application/Service/InformationService.php
@@ -20,6 +20,7 @@ namespace OpenConext\UserLifecycle\Application\Service;
 
 use InvalidArgumentException;
 use OpenConext\UserLifecycle\Domain\Client\DeprovisionClientCollectionInterface;
+use OpenConext\UserLifecycle\Domain\Client\InformationResponseCollectionInterface;
 use OpenConext\UserLifecycle\Domain\Client\InformationResponseInterface;
 use OpenConext\UserLifecycle\Domain\Service\InformationServiceInterface;
 use OpenConext\UserLifecycle\Domain\ValueObject\CollabPersonId;
@@ -49,7 +50,7 @@ class InformationService implements InformationServiceInterface
     /**
      * @param string $personId
      * @throws InvalidArgumentException
-     * @return InformationResponseInterface
+     * @return InformationResponseCollectionInterface
      */
     public function readInformationFor($personId)
     {
@@ -60,11 +61,11 @@ class InformationService implements InformationServiceInterface
         $collabPersonId = new CollabPersonId($personId);
 
         $this->logger->debug('Retrieve the information from the APIs for the user.');
-        $information = json_encode($this->deprovisionClientCollection->information($collabPersonId)->jsonSerialize());
+        $information = $this->deprovisionClientCollection->information($collabPersonId);
 
         $this->logger->info(
             sprintf('Received information for user "%s" with the following data.', $personId),
-            ['information_response' => $information]
+            ['information_response' => json_encode($information->jsonSerialize())]
         );
 
         return $information;

--- a/src/OpenConext/UserLifecycle/Application/Service/InformationService.php
+++ b/src/OpenConext/UserLifecycle/Application/Service/InformationService.php
@@ -65,7 +65,7 @@ class InformationService implements InformationServiceInterface
 
         $this->logger->info(
             sprintf('Received information for user "%s" with the following data.', $personId),
-            ['information_response' => json_encode($information->jsonSerialize())]
+            ['information_response' => json_encode($information)]
         );
 
         return $information;

--- a/src/OpenConext/UserLifecycle/Application/Service/SanityCheckService.php
+++ b/src/OpenConext/UserLifecycle/Application/Service/SanityCheckService.php
@@ -62,7 +62,7 @@ class SanityCheckService implements SanityCheckServiceInterface
      */
     public function check(LastLoginCollectionInterface $lastLoginCollection)
     {
-        $count = $lastLoginCollection->count();
+        $count = count($lastLoginCollection);
 
         if ($count === 0) {
             throw new EmptyLastLoginCollectionException('No candidates found for deprovisioning');

--- a/src/OpenConext/UserLifecycle/Application/Service/SummaryService.php
+++ b/src/OpenConext/UserLifecycle/Application/Service/SummaryService.php
@@ -64,9 +64,9 @@ class SummaryService implements SummaryServiceInterface
 
     private function summarizeInformationResponse(InformationResponseCollectionInterface $collection)
     {
-        $message = sprintf(self::USER_DEPROVISION_FORMAT, $collection->count()) . PHP_EOL;
+        $message = sprintf(self::USER_DEPROVISION_FORMAT, count($collection)) . PHP_EOL;
         if ($this->context === self::CONTEXT_INFORMATION) {
-            $message = sprintf(self::USER_INFORMATION_FORMAT, $collection->count()) . PHP_EOL;
+            $message = sprintf(self::USER_INFORMATION_FORMAT, count($collection)) . PHP_EOL;
         }
 
         $errorMessages = $collection->getErrorMessages();
@@ -84,7 +84,7 @@ class SummaryService implements SummaryServiceInterface
 
     private function summarizeBatchInformationResponse(BatchInformationResponseCollectionInterface $collection)
     {
-        $message = sprintf(self::BATCH_DEPROVISION_FORMAT, $collection->count()) . PHP_EOL;
+        $message = sprintf(self::BATCH_DEPROVISION_FORMAT, count($collection)) . PHP_EOL;
 
         $errorMessageList = '';
 

--- a/src/OpenConext/UserLifecycle/Application/Service/SummaryService.php
+++ b/src/OpenConext/UserLifecycle/Application/Service/SummaryService.php
@@ -1,0 +1,113 @@
+<?php
+
+/**
+ * Copyright 2018 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenConext\UserLifecycle\Application\Service;
+
+use OpenConext\UserLifecycle\Domain\Client\BatchInformationResponseCollectionInterface;
+use OpenConext\UserLifecycle\Domain\Client\InformationResponseCollectionInterface;
+use OpenConext\UserLifecycle\Domain\Service\SummaryServiceInterface;
+use Webmozart\Assert\Assert;
+
+class SummaryService implements SummaryServiceInterface
+{
+
+    const USER_DEPROVISION_FORMAT = 'The user was removed from %d services.';
+    const USER_DEPROVISION_ERROR_FORMAT = 'See error messages below:';
+
+    const USER_INFORMATION_FORMAT = 'Retrieved user information from %d services.';
+
+    const BATCH_DEPROVISION_FORMAT = '%d users have been deprovisioned.';
+    const BATCH_DEPROVISION_ERROR_FORMAT = '%d deprovision calls to services failed. See error messages below:';
+
+    const CONTEXT_INFORMATION = 'information';
+    const CONTEXT_DEPROVISION = 'deprovision';
+
+    private $context = 'deprovision';
+
+    /**
+     * Summarize the information response from a deprovision or
+     * information call.
+     *
+     * @param
+     * @return string
+     */
+    public function summarize($collection)
+    {
+        Assert::isInstanceOfAny(
+            $collection,
+            [InformationResponseCollectionInterface::class, BatchInformationResponseCollectionInterface::class]
+        );
+
+        if ($collection instanceof InformationResponseCollectionInterface) {
+            return $this->summarizeInformationResponse($collection);
+        }
+
+        if ($collection instanceof BatchInformationResponseCollectionInterface) {
+            return $this->summarizeBatchInformationResponse($collection);
+        }
+    }
+
+    private function summarizeInformationResponse(InformationResponseCollectionInterface $collection)
+    {
+        $message = sprintf(self::USER_DEPROVISION_FORMAT, $collection->count()) . PHP_EOL;
+        if ($this->context === self::CONTEXT_INFORMATION) {
+            $message = sprintf(self::USER_INFORMATION_FORMAT, $collection->count()) . PHP_EOL;
+        }
+
+        $errorMessages = $collection->getErrorMessages();
+        $errorMessageList = '';
+        if (!empty($errorMessages)) {
+            $errorMessageList .= sprintf(self::USER_DEPROVISION_ERROR_FORMAT) . PHP_EOL . PHP_EOL;
+
+            foreach ($errorMessages as $errorMessage) {
+                $errorMessageList .= ' * ' . $errorMessage . PHP_EOL;
+            }
+        }
+
+        return $message . $errorMessageList;
+    }
+
+    private function summarizeBatchInformationResponse(BatchInformationResponseCollectionInterface $collection)
+    {
+        $message = sprintf(self::BATCH_DEPROVISION_FORMAT, $collection->count()) . PHP_EOL;
+
+        $errorMessageList = '';
+
+        $errorMessages = $collection->getErrorMessages();
+        if (!empty($errorMessages)) {
+            $errorMessageList .= sprintf(self::BATCH_DEPROVISION_ERROR_FORMAT, count($errorMessages)) . PHP_EOL . PHP_EOL;
+            foreach ($errorMessages as $errorMessage) {
+                $errorMessageList .= ' * ' . $errorMessage . PHP_EOL;
+            }
+        }
+
+        return $message . $errorMessageList;
+    }
+
+    /**
+     * Set the context to deprovision or information outputting
+     *
+     * @param string $context
+     */
+    public function setContext($context)
+    {
+        Assert::stringNotEmpty($context);
+        Assert::oneOf($context, [self::CONTEXT_INFORMATION, self::CONTEXT_DEPROVISION]);
+        $this->context = $context;
+    }
+}

--- a/src/OpenConext/UserLifecycle/Application/Service/SummaryService.php
+++ b/src/OpenConext/UserLifecycle/Application/Service/SummaryService.php
@@ -21,7 +21,6 @@ namespace OpenConext\UserLifecycle\Application\Service;
 use OpenConext\UserLifecycle\Domain\Client\BatchInformationResponseCollectionInterface;
 use OpenConext\UserLifecycle\Domain\Client\InformationResponseCollectionInterface;
 use OpenConext\UserLifecycle\Domain\Service\SummaryServiceInterface;
-use Webmozart\Assert\Assert;
 
 class SummaryService implements SummaryServiceInterface
 {
@@ -34,80 +33,54 @@ class SummaryService implements SummaryServiceInterface
     const BATCH_DEPROVISION_FORMAT = '%d users have been deprovisioned.';
     const BATCH_DEPROVISION_ERROR_FORMAT = '%d deprovision calls to services failed. See error messages below:';
 
-    const CONTEXT_INFORMATION = 'information';
-    const CONTEXT_DEPROVISION = 'deprovision';
-
-    private $context = 'deprovision';
-
-    /**
-     * Summarize the information response from a deprovision or
-     * information call.
-     *
-     * @param
-     * @return string
-     */
-    public function summarize($collection)
+    public function summarizeInformationResponse(InformationResponseCollectionInterface $collection)
     {
-        Assert::isInstanceOfAny(
-            $collection,
-            [InformationResponseCollectionInterface::class, BatchInformationResponseCollectionInterface::class]
-        );
-
-        if ($collection instanceof InformationResponseCollectionInterface) {
-            return $this->summarizeInformationResponse($collection);
-        }
-
-        if ($collection instanceof BatchInformationResponseCollectionInterface) {
-            return $this->summarizeBatchInformationResponse($collection);
-        }
-    }
-
-    private function summarizeInformationResponse(InformationResponseCollectionInterface $collection)
-    {
-        $message = sprintf(self::USER_DEPROVISION_FORMAT, count($collection)) . PHP_EOL;
-        if ($this->context === self::CONTEXT_INFORMATION) {
-            $message = sprintf(self::USER_INFORMATION_FORMAT, count($collection)) . PHP_EOL;
-        }
+        $message = sprintf(self::USER_INFORMATION_FORMAT, count($collection)).PHP_EOL;
 
         $errorMessages = $collection->getErrorMessages();
         $errorMessageList = '';
         if (!empty($errorMessages)) {
-            $errorMessageList .= sprintf(self::USER_DEPROVISION_ERROR_FORMAT) . PHP_EOL . PHP_EOL;
+            $errorMessageList .= sprintf(self::USER_DEPROVISION_ERROR_FORMAT).PHP_EOL.PHP_EOL;
 
             foreach ($errorMessages as $errorMessage) {
-                $errorMessageList .= ' * ' . $errorMessage . PHP_EOL;
+                $errorMessageList .= ' * '.$errorMessage.PHP_EOL;
             }
         }
 
-        return $message . $errorMessageList;
+        return $message.$errorMessageList;
     }
 
-    private function summarizeBatchInformationResponse(BatchInformationResponseCollectionInterface $collection)
+    public function summarizeDeprovisionResponse(InformationResponseCollectionInterface $collection)
     {
-        $message = sprintf(self::BATCH_DEPROVISION_FORMAT, count($collection)) . PHP_EOL;
+        $message = sprintf(self::USER_DEPROVISION_FORMAT, count($collection)).PHP_EOL;
+
+        $errorMessages = $collection->getErrorMessages();
+        $errorMessageList = '';
+        if (!empty($errorMessages)) {
+            $errorMessageList .= sprintf(self::USER_DEPROVISION_ERROR_FORMAT).PHP_EOL.PHP_EOL;
+
+            foreach ($errorMessages as $errorMessage) {
+                $errorMessageList .= ' * '.$errorMessage.PHP_EOL;
+            }
+        }
+
+        return $message.$errorMessageList;
+    }
+
+    public function summarizeBatchResponse(BatchInformationResponseCollectionInterface $collection)
+    {
+        $message = sprintf(self::BATCH_DEPROVISION_FORMAT, count($collection)).PHP_EOL;
 
         $errorMessageList = '';
 
         $errorMessages = $collection->getErrorMessages();
         if (!empty($errorMessages)) {
-            $errorMessageList .= sprintf(self::BATCH_DEPROVISION_ERROR_FORMAT, count($errorMessages)) . PHP_EOL . PHP_EOL;
+            $errorMessageList .= sprintf(self::BATCH_DEPROVISION_ERROR_FORMAT, count($errorMessages)).PHP_EOL.PHP_EOL;
             foreach ($errorMessages as $errorMessage) {
-                $errorMessageList .= ' * ' . $errorMessage . PHP_EOL;
+                $errorMessageList .= ' * '.$errorMessage.PHP_EOL;
             }
         }
 
-        return $message . $errorMessageList;
-    }
-
-    /**
-     * Set the context to deprovision or information outputting
-     *
-     * @param string $context
-     */
-    public function setContext($context)
-    {
-        Assert::stringNotEmpty($context);
-        Assert::oneOf($context, [self::CONTEXT_INFORMATION, self::CONTEXT_DEPROVISION]);
-        $this->context = $context;
+        return $message.$errorMessageList;
     }
 }

--- a/src/OpenConext/UserLifecycle/Domain/Client/BatchInformationResponseCollection.php
+++ b/src/OpenConext/UserLifecycle/Domain/Client/BatchInformationResponseCollection.php
@@ -32,8 +32,34 @@ class BatchInformationResponseCollection implements BatchInformationResponseColl
         $this->data[$personId->getCollabPersonId()] = $collection;
     }
 
+    /**
+     * @return int
+     */
+    public function count()
+    {
+        return count($this->data);
+    }
+
     public function jsonSerialize()
     {
         return $this->data;
+    }
+
+    /**
+     * Get an array of error messages in string format
+     * @return string[]
+     */
+    public function getErrorMessages()
+    {
+        $messages = [];
+        foreach ($this->data as $collabPersonId => $collection) {
+            $errorMessages = $collection->getErrorMessages();
+            if (!empty($errorMessages)) {
+                foreach ($errorMessages as $message) {
+                    $messages[] = sprintf('"%s" for user "%s"', $message, $collabPersonId);
+                }
+            }
+        }
+        return $messages;
     }
 }

--- a/src/OpenConext/UserLifecycle/Domain/Client/BatchInformationResponseCollection.php
+++ b/src/OpenConext/UserLifecycle/Domain/Client/BatchInformationResponseCollection.php
@@ -55,8 +55,8 @@ class BatchInformationResponseCollection implements BatchInformationResponseColl
         foreach ($this->data as $collabPersonId => $collection) {
             $errorMessages = $collection->getErrorMessages();
             if (!empty($errorMessages)) {
-                foreach ($errorMessages as $message) {
-                    $messages[] = sprintf('"%s" for user "%s"', $message, $collabPersonId);
+                foreach ($errorMessages as $serviceName => $message) {
+                    $messages[] = sprintf('%s: "%s" for user "%s"', $serviceName, $message, $collabPersonId);
                 }
             }
         }

--- a/src/OpenConext/UserLifecycle/Domain/Client/BatchInformationResponseCollection.php
+++ b/src/OpenConext/UserLifecycle/Domain/Client/BatchInformationResponseCollection.php
@@ -34,6 +34,6 @@ class BatchInformationResponseCollection implements BatchInformationResponseColl
 
     public function jsonSerialize()
     {
-        return json_encode($this->data, JSON_PRETTY_PRINT);
+        return $this->data;
     }
 }

--- a/src/OpenConext/UserLifecycle/Domain/Client/BatchInformationResponseCollectionInterface.php
+++ b/src/OpenConext/UserLifecycle/Domain/Client/BatchInformationResponseCollectionInterface.php
@@ -34,7 +34,18 @@ interface BatchInformationResponseCollectionInterface extends JsonSerializable
     public function add(CollabPersonId $personId, InformationResponseCollectionInterface $collection);
 
     /**
+     * @return int
+     */
+    public function count();
+
+    /**
      * @return array
      */
     public function jsonSerialize();
+
+    /**
+     * Get an array of error messages in string format
+     * @return string[]
+     */
+    public function getErrorMessages();
 }

--- a/src/OpenConext/UserLifecycle/Domain/Client/BatchInformationResponseCollectionInterface.php
+++ b/src/OpenConext/UserLifecycle/Domain/Client/BatchInformationResponseCollectionInterface.php
@@ -18,10 +18,11 @@
 
 namespace OpenConext\UserLifecycle\Domain\Client;
 
+use Countable;
 use JsonSerializable;
 use OpenConext\UserLifecycle\Domain\ValueObject\CollabPersonId;
 
-interface BatchInformationResponseCollectionInterface extends JsonSerializable
+interface BatchInformationResponseCollectionInterface extends JsonSerializable, Countable
 {
     /**
      * Collects InformationResponseCollection objects indexed on the

--- a/src/OpenConext/UserLifecycle/Domain/Client/InformationResponse.php
+++ b/src/OpenConext/UserLifecycle/Domain/Client/InformationResponse.php
@@ -85,6 +85,6 @@ class InformationResponse implements InformationResponseInterface
             $response['message'] = (string) $this->getErrorMessage();
         }
 
-        return json_encode($response);
+        return $response;
     }
 }

--- a/src/OpenConext/UserLifecycle/Domain/Client/InformationResponseCollection.php
+++ b/src/OpenConext/UserLifecycle/Domain/Client/InformationResponseCollection.php
@@ -56,6 +56,6 @@ class InformationResponseCollection implements InformationResponseCollectionInte
 
     public function jsonSerialize()
     {
-        return json_encode($this->data, JSON_PRETTY_PRINT);
+        return $this->data;
     }
 }

--- a/src/OpenConext/UserLifecycle/Domain/Client/InformationResponseCollection.php
+++ b/src/OpenConext/UserLifecycle/Domain/Client/InformationResponseCollection.php
@@ -41,7 +41,7 @@ class InformationResponseCollection implements InformationResponseCollectionInte
     }
 
     /**
-     * @return ErrorMessage[]
+     * @return string[]
      */
     public function getErrorMessages()
     {
@@ -57,5 +57,13 @@ class InformationResponseCollection implements InformationResponseCollectionInte
     public function jsonSerialize()
     {
         return $this->data;
+    }
+
+    /**
+     * @return int
+     */
+    public function count()
+    {
+        return count($this->data);
     }
 }

--- a/src/OpenConext/UserLifecycle/Domain/Client/InformationResponseCollection.php
+++ b/src/OpenConext/UserLifecycle/Domain/Client/InformationResponseCollection.php
@@ -18,8 +18,6 @@
 
 namespace OpenConext\UserLifecycle\Domain\Client;
 
-use OpenConext\UserLifecycle\Domain\ValueObject\Client\ErrorMessage;
-
 class InformationResponseCollection implements InformationResponseCollectionInterface
 {
     /**

--- a/src/OpenConext/UserLifecycle/Domain/Client/InformationResponseCollectionInterface.php
+++ b/src/OpenConext/UserLifecycle/Domain/Client/InformationResponseCollectionInterface.php
@@ -19,7 +19,6 @@
 namespace OpenConext\UserLifecycle\Domain\Client;
 
 use JsonSerializable;
-use OpenConext\UserLifecycle\Domain\ValueObject\Client\ErrorMessage;
 
 interface InformationResponseCollectionInterface extends JsonSerializable
 {

--- a/src/OpenConext/UserLifecycle/Domain/Client/InformationResponseCollectionInterface.php
+++ b/src/OpenConext/UserLifecycle/Domain/Client/InformationResponseCollectionInterface.php
@@ -34,7 +34,7 @@ interface InformationResponseCollectionInterface extends JsonSerializable
     public function getInformationResponses();
 
     /**
-     * @return ErrorMessage[]
+     * @return string[]
      */
     public function getErrorMessages();
 
@@ -42,4 +42,9 @@ interface InformationResponseCollectionInterface extends JsonSerializable
      * @return array
      */
     public function jsonSerialize();
+
+    /**
+     * @return int
+     */
+    public function count();
 }

--- a/src/OpenConext/UserLifecycle/Domain/Client/InformationResponseCollectionInterface.php
+++ b/src/OpenConext/UserLifecycle/Domain/Client/InformationResponseCollectionInterface.php
@@ -19,8 +19,9 @@
 namespace OpenConext\UserLifecycle\Domain\Client;
 
 use JsonSerializable;
+use Countable;
 
-interface InformationResponseCollectionInterface extends JsonSerializable
+interface InformationResponseCollectionInterface extends JsonSerializable, Countable
 {
     /**
      * @param InformationResponseInterface $informationResponse

--- a/src/OpenConext/UserLifecycle/Domain/Collection/LastLoginCollectionInterface.php
+++ b/src/OpenConext/UserLifecycle/Domain/Collection/LastLoginCollectionInterface.php
@@ -18,9 +18,10 @@
 
 namespace OpenConext\UserLifecycle\Domain\Collection;
 
+use Countable;
 use OpenConext\UserLifecycle\Domain\Entity\LastLogin;
 
-interface LastLoginCollectionInterface
+interface LastLoginCollectionInterface extends Countable
 {
     /**
      * @param array $results

--- a/src/OpenConext/UserLifecycle/Domain/Service/InformationServiceInterface.php
+++ b/src/OpenConext/UserLifecycle/Domain/Service/InformationServiceInterface.php
@@ -18,11 +18,13 @@
 
 namespace OpenConext\UserLifecycle\Domain\Service;
 
+use OpenConext\UserLifecycle\Domain\Client\InformationResponseInterface;
+
 interface InformationServiceInterface
 {
     /**
      * @param string $personId
-     * @return string
+     * @return InformationResponseInterface
      */
     public function readInformationFor($personId);
 }

--- a/src/OpenConext/UserLifecycle/Domain/Service/SummaryServiceInterface.php
+++ b/src/OpenConext/UserLifecycle/Domain/Service/SummaryServiceInterface.php
@@ -18,21 +18,32 @@
 
 namespace OpenConext\UserLifecycle\Domain\Service;
 
+use OpenConext\UserLifecycle\Domain\Client\BatchInformationResponseCollectionInterface;
+use OpenConext\UserLifecycle\Domain\Client\InformationResponseCollectionInterface;
+
 interface SummaryServiceInterface
 {
     /**
-     * Summarize the information response from a deprovision or
-     * information call.
+     * Summarize the information response from an information call.
      *
-     * @param
+     * @param InformationResponseCollectionInterface $collection
      * @return string
      */
-    public function summarize($collection);
+    public function summarizeInformationResponse(InformationResponseCollectionInterface $collection);
 
     /**
-     * Set the context to deprovision or information outputting
+     * Summarize the information response from a deprovision call.
      *
-     * @param $context
+     * @param InformationResponseCollectionInterface $collection
+     * @return string
      */
-    public function setContext($context);
+    public function summarizeDeprovisionResponse(InformationResponseCollectionInterface $collection);
+
+    /**
+     * Summarize the information response from a batch deprovision call.
+     *
+     * @param BatchInformationResponseCollectionInterface $collection
+     * @return string
+     */
+    public function summarizeBatchResponse(BatchInformationResponseCollectionInterface $collection);
 }

--- a/src/OpenConext/UserLifecycle/Domain/Service/SummaryServiceInterface.php
+++ b/src/OpenConext/UserLifecycle/Domain/Service/SummaryServiceInterface.php
@@ -18,23 +18,21 @@
 
 namespace OpenConext\UserLifecycle\Domain\Service;
 
-use OpenConext\UserLifecycle\Domain\Client\BatchInformationResponseCollectionInterface;
-use OpenConext\UserLifecycle\Domain\Client\InformationResponseCollectionInterface;
-
-interface DeprovisionServiceInterface
+interface SummaryServiceInterface
 {
     /**
-     * @param string $personId
-     * @param bool $dryRun
-     * @return InformationResponseCollectionInterface
+     * Summarize the information response from a deprovision or
+     * information call.
+     *
+     * @param
+     * @return string
      */
-    public function deprovision($personId, $dryRun = false);
+    public function summarize($collection);
 
     /**
-     * Finds the users marked for deprovisioning, and deprovisions them.
+     * Set the context to deprovision or information outputting
      *
-     * @param bool $dryRun
-     * @return BatchInformationResponseCollectionInterface
+     * @param $context
      */
-    public function batchDeprovision($dryRun = false);
+    public function setContext($context);
 }

--- a/src/OpenConext/UserLifecycle/Infrastructure/UserLifecycleBundle/Command/DeprovisionCommand.php
+++ b/src/OpenConext/UserLifecycle/Infrastructure/UserLifecycleBundle/Command/DeprovisionCommand.php
@@ -137,7 +137,7 @@ class DeprovisionCommand extends Command
 
             if (!$isQuiet) {
                 $output->writeln(PHP_EOL);
-                $output->write($this->summaryService->summarize($information), true);
+                $output->write($this->summaryService->summarizeBatchResponse($information), true);
                 $output->writeln('Full output of the deprovisioning command:' . PHP_EOL);
             }
 
@@ -179,7 +179,7 @@ class DeprovisionCommand extends Command
 
             if (!$isQuiet) {
                 $output->writeln(PHP_EOL);
-                $output->write($this->summaryService->summarize($information), true);
+                $output->write($this->summaryService->summarizeDeprovisionResponse($information), true);
                 $output->writeln('Full output of the deprovisioning command:' . PHP_EOL);
             }
 

--- a/src/OpenConext/UserLifecycle/Infrastructure/UserLifecycleBundle/Command/DeprovisionCommand.php
+++ b/src/OpenConext/UserLifecycle/Infrastructure/UserLifecycleBundle/Command/DeprovisionCommand.php
@@ -141,7 +141,7 @@ class DeprovisionCommand extends Command
                 $output->writeln('Full output of the deprovisioning command:' . PHP_EOL);
             }
 
-            $output->write(json_encode($information->jsonSerialize()), true);
+            $output->write(json_encode($information), true);
         } catch (InvalidArgumentException $e) {
             $this->logger->error($e->getMessage());
         }
@@ -183,7 +183,7 @@ class DeprovisionCommand extends Command
                 $output->writeln('Full output of the deprovisioning command:' . PHP_EOL);
             }
 
-            $output->write(json_encode($information->jsonSerialize()), true);
+            $output->write(json_encode($information), true);
         } catch (InvalidArgumentException $e) {
             $this->logger->error($e->getMessage());
         }

--- a/src/OpenConext/UserLifecycle/Infrastructure/UserLifecycleBundle/Command/DeprovisionCommand.php
+++ b/src/OpenConext/UserLifecycle/Infrastructure/UserLifecycleBundle/Command/DeprovisionCommand.php
@@ -99,7 +99,7 @@ class DeprovisionCommand extends Command
     {
         if (!$forced) {
             $helper = $this->getHelper('question');
-            $question = new ConfirmationQuestion(sprintf('Continue with deprovisioning? (y/n)', $userIdInput), false);
+            $question = new ConfirmationQuestion(sprintf('<question>Continue with deprovisioning? (y/n)</question> ', $userIdInput), false);
 
             if (!$helper->ask($input, $output, $question)) {
                 return;
@@ -124,7 +124,7 @@ class DeprovisionCommand extends Command
     {
         if (!$forced) {
             $helper = $this->getHelper('question');
-            $question = new ConfirmationQuestion(sprintf('Continue with deprovisioning of "%s"? (y/n)', $userIdInput), false);
+            $question = new ConfirmationQuestion(sprintf('<question>Continue with deprovisioning of "%s"? (y/n)</question> ', $userIdInput), false);
 
             if (!$helper->ask($input, $output, $question)) {
                 return;

--- a/src/OpenConext/UserLifecycle/Infrastructure/UserLifecycleBundle/Command/InformationCommand.php
+++ b/src/OpenConext/UserLifecycle/Infrastructure/UserLifecycleBundle/Command/InformationCommand.php
@@ -54,7 +54,6 @@ class InformationCommand extends Command
         parent::__construct(null);
         $this->service = $informationDeprovisionService;
         $this->summaryService = $summaryService;
-        $this->summaryService->setContext(SummaryService::CONTEXT_INFORMATION);
         $this->logger = $logger;
     }
 
@@ -97,7 +96,7 @@ class InformationCommand extends Command
 
             if (!$isQuiet) {
                 $output->writeln(PHP_EOL);
-                $output->write($this->summaryService->summarize($information), true);
+                $output->write($this->summaryService->summarizeInformationResponse($information), true);
                 $output->writeln('Full output of the deprovisioning command:' . PHP_EOL);
             }
 

--- a/src/OpenConext/UserLifecycle/Infrastructure/UserLifecycleBundle/Command/InformationCommand.php
+++ b/src/OpenConext/UserLifecycle/Infrastructure/UserLifecycleBundle/Command/InformationCommand.php
@@ -101,7 +101,7 @@ class InformationCommand extends Command
                 $output->writeln('Full output of the deprovisioning command:' . PHP_EOL);
             }
 
-            $output->write(json_encode($information->jsonSerialize()), true);
+            $output->write(json_encode($information), true);
         } catch (InvalidArgumentException $e) {
             $this->logger->error($e->getMessage());
         }

--- a/src/OpenConext/UserLifecycle/Infrastructure/UserLifecycleBundle/Resources/config/services.yml
+++ b/src/OpenConext/UserLifecycle/Infrastructure/UserLifecycleBundle/Resources/config/services.yml
@@ -25,6 +25,7 @@ services:
     OpenConext\UserLifecycle\Infrastructure\UserLifecycleBundle\Command\InformationCommand:
         arguments:
             - '@OpenConext\UserLifecycle\Application\Service\InformationService'
+            - '@OpenConext\UserLifecycle\Application\Service\SummaryService'
             - '@logger'
         tags:
             - 'console.command'
@@ -32,6 +33,7 @@ services:
     OpenConext\UserLifecycle\Infrastructure\UserLifecycleBundle\Command\DeprovisionCommand:
         arguments:
             - '@OpenConext\UserLifecycle\Application\Service\DeprovisionService'
+            - '@OpenConext\UserLifecycle\Application\Service\SummaryService'
             - '@logger'
         tags:
             - 'console.command'

--- a/tests/integration/UserLifecycleBundle/Command/DeprovisionCommandTest.php
+++ b/tests/integration/UserLifecycleBundle/Command/DeprovisionCommandTest.php
@@ -23,6 +23,7 @@ use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\Psr7\Response;
 use Mockery as m;
 use OpenConext\UserLifecycle\Application\Service\DeprovisionService;
+use OpenConext\UserLifecycle\Application\Service\SummaryService;
 use OpenConext\UserLifecycle\Domain\Entity\LastLogin;
 use OpenConext\UserLifecycle\Infrastructure\UserLifecycleBundle\Command\DeprovisionCommand;
 use OpenConext\UserLifecycle\Infrastructure\UserLifecycleBundle\Repository\LastLoginRepository;
@@ -90,11 +91,12 @@ class DeprovisionCommandTest extends DatabaseTestCase
         $this->repository->setNow(new DateTime('2018-01-01'));
 
         $deprovisionService = $this->container->get(DeprovisionService::class);
+        $summaryService = new SummaryService();
 
         $logger = m::mock(LoggerInterface::class);
         $logger->shouldIgnoreMissing();
 
-        $this->application->add(new DeprovisionCommand($deprovisionService, $logger));
+        $this->application->add(new DeprovisionCommand($deprovisionService, $summaryService, $logger));
 
         // Load the database fixtures
         $this->loadFixtures();

--- a/tests/integration/UserLifecycleBundle/Command/InformationCommandTest.php
+++ b/tests/integration/UserLifecycleBundle/Command/InformationCommandTest.php
@@ -22,6 +22,7 @@ use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\Psr7\Response;
 use Mockery as m;
 use OpenConext\UserLifecycle\Application\Service\InformationService;
+use OpenConext\UserLifecycle\Application\Service\SummaryService;
 use OpenConext\UserLifecycle\Infrastructure\UserLifecycleBundle\Command\InformationCommand;
 use OpenConext\UserLifecycle\Tests\Integration\DatabaseTestCase;
 use Psr\Container\ContainerInterface;
@@ -78,11 +79,12 @@ class LastLoginRepositoryTest extends DatabaseTestCase
         $this->application = new Application(self::$kernel);
 
         $lastLoginService = self::$kernel->getContainer()->get(InformationService::class);
+        $summaryService = new SummaryService();
 
         $logger = m::mock(LoggerInterface::class);
         $logger->shouldIgnoreMissing();
 
-        $this->application->add(new InformationCommand($lastLoginService, $logger));
+        $this->application->add(new InformationCommand($lastLoginService, $summaryService, $logger));
 
         // Load the database fixtures
         $this->loadFixtures();

--- a/tests/unit/Application/Service/DeprovisionServiceTest.php
+++ b/tests/unit/Application/Service/DeprovisionServiceTest.php
@@ -118,7 +118,7 @@ class DeprovisionServiceTest extends TestCase
         // Call the readInformationFor method
         $response = $this->service->deprovision($personId);
 
-        $this->assertJson($response);
+        $this->assertInstanceOf(InformationResponseCollectionInterface::class, $response);
     }
 
     public function test_deprovision_dry_run()
@@ -141,7 +141,7 @@ class DeprovisionServiceTest extends TestCase
         // Call the readInformationFor method
         $response = $this->service->deprovision($personId, true);
 
-        $this->assertJson($response);
+        $this->assertInstanceOf(InformationResponseCollectionInterface::class, $response);
     }
 
     public function test_deprovision_empty_person_id()

--- a/tests/unit/Application/Service/InformationServiceTest.php
+++ b/tests/unit/Application/Service/InformationServiceTest.php
@@ -65,7 +65,7 @@ class InformationServiceTest extends TestCase
 
         // Call the readInformationFor method
         $response = $this->service->readInformationFor($personId);
-        $this->assertJson($response);
+        $this->assertInstanceOf(InformationResponseCollection::class, $response);
     }
 
     public function test_read_information_empty_person_id()

--- a/tests/unit/Application/Service/SummaryServiceTest.php
+++ b/tests/unit/Application/Service/SummaryServiceTest.php
@@ -103,18 +103,18 @@ class SummaryServiceTest extends TestCase
         $collection
             ->shouldReceive('getErrorMessages')
             ->andReturn([
-                '"Error message" for user "collabPersonId"',
-                '"EngineBlock not available" for user "urn:collab:jane_doe"',
-                '"DropjesService has gone away" for user "urn:collab:jack_black"',
+                'Service name: "Error message" for user "collabPersonId"',
+                'EngineBlock: "Service not available" for user "urn:collab:jane_doe"',
+                'DropjesService: "Server has gone away" for user "urn:collab:jack_black"',
             ]);
 
         $summary = $this->service->summarize($collection);
 
         $this->assertContains('256 users have been deprovisioned.', $summary);
         $this->assertContains('3 deprovision calls to services failed. See error messages below:', $summary);
-        $this->assertContains(' * "Error message" for user "collabPersonId"', $summary);
-        $this->assertContains(' * "EngineBlock not available" for user "urn:collab:jane_doe"', $summary);
-        $this->assertContains(' * "DropjesService has gone away" for user "urn:collab:jack_black"', $summary);
+        $this->assertContains(' * Service name: "Error message" for user "collabPersonId"', $summary);
+        $this->assertContains(' * EngineBlock: "Service not available" for user "urn:collab:jane_doe"', $summary);
+        $this->assertContains(' * DropjesService: "Server has gone away" for user "urn:collab:jack_black"', $summary);
     }
 
     public function test_summarize_information_collection_information_context()

--- a/tests/unit/Application/Service/SummaryServiceTest.php
+++ b/tests/unit/Application/Service/SummaryServiceTest.php
@@ -52,7 +52,7 @@ class SummaryServiceTest extends TestCase
             ->shouldReceive('getErrorMessages')
             ->andReturn([]);
 
-        $summary = $this->service->summarize($collection);
+        $summary = $this->service->summarizeDeprovisionResponse($collection);
 
         $this->assertContains('The user was removed from 5 services.', $summary);
         $this->assertNotContains('See error messages below:', $summary);
@@ -69,7 +69,7 @@ class SummaryServiceTest extends TestCase
             ->shouldReceive('getErrorMessages')
             ->andReturn(['Fake error message']);
 
-        $summary = $this->service->summarize($collection);
+        $summary = $this->service->summarizeDeprovisionResponse($collection);
 
         $this->assertContains('The user was removed from 5 services.', $summary);
         $this->assertContains('See error messages below:', $summary);
@@ -87,7 +87,7 @@ class SummaryServiceTest extends TestCase
             ->shouldReceive('getErrorMessages')
             ->andReturn([]);
 
-        $summary = $this->service->summarize($collection);
+        $summary = $this->service->summarizeBatchResponse($collection);
 
         $this->assertContains('256 users have been deprovisioned.', $summary);
         $this->assertNotContains('See error messages below:', $summary);
@@ -108,7 +108,7 @@ class SummaryServiceTest extends TestCase
                 'DropjesService: "Server has gone away" for user "urn:collab:jack_black"',
             ]);
 
-        $summary = $this->service->summarize($collection);
+        $summary = $this->service->summarizeBatchResponse($collection);
 
         $this->assertContains('256 users have been deprovisioned.', $summary);
         $this->assertContains('3 deprovision calls to services failed. See error messages below:', $summary);
@@ -119,7 +119,6 @@ class SummaryServiceTest extends TestCase
 
     public function test_summarize_information_collection_information_context()
     {
-        $this->service->setContext(SummaryService::CONTEXT_INFORMATION);
 
         $collection = m::mock(InformationResponseCollectionInterface::class);
         $collection
@@ -130,17 +129,9 @@ class SummaryServiceTest extends TestCase
             ->shouldReceive('getErrorMessages')
             ->andReturn([]);
 
-        $summary = $this->service->summarize($collection);
+        $summary = $this->service->summarizeInformationResponse($collection);
 
         $this->assertContains('Retrieved user information from 5 services.', $summary);
         $this->assertNotContains('See error messages below:', $summary);
-    }
-
-    /**
-     * @expectedException \InvalidArgumentException
-     */
-    public function test_invalid_input()
-    {
-        $this->service->summarize(['foo', 'bar']);
     }
 }

--- a/tests/unit/Application/Service/SummaryServiceTest.php
+++ b/tests/unit/Application/Service/SummaryServiceTest.php
@@ -1,0 +1,146 @@
+<?php
+
+/**
+ * Copyright 2018 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenConext\UserLifecycle\Tests\Unit\Application\Service;
+
+use Mockery as m;
+use Mockery\Mock;
+use OpenConext\UserLifecycle\Application\Service\SanityCheckService;
+use OpenConext\UserLifecycle\Application\Service\SummaryService;
+use OpenConext\UserLifecycle\Domain\Client\BatchInformationResponseCollectionInterface;
+use OpenConext\UserLifecycle\Domain\Client\InformationResponseCollectionInterface;
+use OpenConext\UserLifecycle\Domain\Collection\LastLoginCollectionInterface;
+use OpenConext\UserLifecycle\Domain\ValueObject\Client\ErrorMessage;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+class SummaryServiceTest extends TestCase
+{
+    /**
+     * @var SummaryService
+     */
+    private $service;
+
+    public function setUp()
+    {
+        $this->service = new SummaryService();
+    }
+
+    public function test_summarize_information_collection()
+    {
+        $collection = m::mock(InformationResponseCollectionInterface::class);
+        $collection
+            ->shouldReceive('count')
+            ->andReturn(5);
+
+        $collection
+            ->shouldReceive('getErrorMessages')
+            ->andReturn([]);
+
+        $summary = $this->service->summarize($collection);
+
+        $this->assertContains('The user was removed from 5 services.', $summary);
+        $this->assertNotContains('See error messages below:', $summary);
+    }
+
+    public function test_summarize_information_collection_with_errors()
+    {
+        $collection = m::mock(InformationResponseCollectionInterface::class);
+        $collection
+            ->shouldReceive('count')
+            ->andReturn(5);
+
+        $collection
+            ->shouldReceive('getErrorMessages')
+            ->andReturn(['Fake error message']);
+
+        $summary = $this->service->summarize($collection);
+
+        $this->assertContains('The user was removed from 5 services.', $summary);
+        $this->assertContains('See error messages below:', $summary);
+        $this->assertContains(' * Fake error message', $summary);
+    }
+
+    public function test_summarize_batch_information_collection()
+    {
+        $collection = m::mock(BatchInformationResponseCollectionInterface::class);
+        $collection
+            ->shouldReceive('count')
+            ->andReturn(256);
+
+        $collection
+            ->shouldReceive('getErrorMessages')
+            ->andReturn([]);
+
+        $summary = $this->service->summarize($collection);
+
+        $this->assertContains('256 users have been deprovisioned.', $summary);
+        $this->assertNotContains('See error messages below:', $summary);
+    }
+
+    public function test_summarize_batch_information_collection_with_errors()
+    {
+        $collection = m::mock(BatchInformationResponseCollectionInterface::class);
+        $collection
+            ->shouldReceive('count')
+            ->andReturn(256);
+
+        $collection
+            ->shouldReceive('getErrorMessages')
+            ->andReturn([
+                '"Error message" for user "collabPersonId"',
+                '"EngineBlock not available" for user "urn:collab:jane_doe"',
+                '"DropjesService has gone away" for user "urn:collab:jack_black"',
+            ]);
+
+        $summary = $this->service->summarize($collection);
+
+        $this->assertContains('256 users have been deprovisioned.', $summary);
+        $this->assertContains('3 deprovision calls to services failed. See error messages below:', $summary);
+        $this->assertContains(' * "Error message" for user "collabPersonId"', $summary);
+        $this->assertContains(' * "EngineBlock not available" for user "urn:collab:jane_doe"', $summary);
+        $this->assertContains(' * "DropjesService has gone away" for user "urn:collab:jack_black"', $summary);
+    }
+
+    public function test_summarize_information_collection_information_context()
+    {
+        $this->service->setContext(SummaryService::CONTEXT_INFORMATION);
+
+        $collection = m::mock(InformationResponseCollectionInterface::class);
+        $collection
+            ->shouldReceive('count')
+            ->andReturn(5);
+
+        $collection
+            ->shouldReceive('getErrorMessages')
+            ->andReturn([]);
+
+        $summary = $this->service->summarize($collection);
+
+        $this->assertContains('Retrieved user information from 5 services.', $summary);
+        $this->assertNotContains('See error messages below:', $summary);
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function test_invalid_input()
+    {
+        $this->service->summarize(['foo', 'bar']);
+    }
+}

--- a/tests/unit/Domain/Client/BatchInformationResponseCollectionTest.php
+++ b/tests/unit/Domain/Client/BatchInformationResponseCollectionTest.php
@@ -1,0 +1,73 @@
+<?php
+
+/**
+ * Copyright 2018 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenConext\UserLifecycle\Tests\Unit\Domain\Client;
+
+use Mockery as m;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use OpenConext\UserLifecycle\Domain\Client\BatchInformationResponseCollection;
+use OpenConext\UserLifecycle\Domain\Client\InformationResponseCollection;
+use OpenConext\UserLifecycle\Domain\Client\InformationResponseInterface;
+use OpenConext\UserLifecycle\Domain\ValueObject\Client\Data;
+use OpenConext\UserLifecycle\Domain\ValueObject\Client\ErrorMessage;
+use OpenConext\UserLifecycle\Domain\ValueObject\Client\Name;
+use OpenConext\UserLifecycle\Domain\ValueObject\Client\ResponseStatus;
+use OpenConext\UserLifecycle\Domain\ValueObject\CollabPersonId;
+use PHPUnit\Framework\TestCase;
+
+class BatchInformationResponseCollectionTest extends TestCase
+{
+    use MockeryPHPUnitIntegration;
+
+    public function test_can_be_created()
+    {
+        $collection = new BatchInformationResponseCollection();
+        $this->assertEquals(0, $collection->count());
+        $this->assertEmpty($collection->getErrorMessages());
+    }
+
+    public function test_it_composes_readable_error_messages()
+    {
+        $user1 = m::mock(CollabPersonId::class);
+        $user1
+            ->shouldReceive('getCollabPersonId')
+            ->andReturn('JK');
+
+        $collection = m::mock(InformationResponseCollection::class);
+        $collection
+            ->shouldReceive('getErrorMessages')
+            ->andReturn([
+                'service1' => 'service is not available',
+                'service2' => 'service is not available',
+                'service3' => 'service is not available',
+                'service4' => 'service is not available',
+            ]);
+
+        $batchCollection = new BatchInformationResponseCollection();
+        $batchCollection->add($user1, $collection);
+
+        $this->assertEquals(1, $batchCollection->count());
+
+        $errorMessages = $batchCollection->getErrorMessages();
+        $this->assertCount(4, $errorMessages);
+        $this->assertEquals('service1: "service is not available" for user "JK"', $errorMessages[0]);
+        $this->assertEquals('service2: "service is not available" for user "JK"', $errorMessages[1]);
+        $this->assertEquals('service3: "service is not available" for user "JK"', $errorMessages[2]);
+        $this->assertEquals('service4: "service is not available" for user "JK"', $errorMessages[3]);
+    }
+}


### PR DESCRIPTION
So `bin/console user-lifecycle:information --user=foobar` turns into
`bin/console user-lifecycle:information foobar`