### PR TITLE
Turn user option into an argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,16 +33,12 @@ TODO: describe DELETE feature and its --dry-run option.
 ## Gather information about a user
 To read user information you can use the `user-lifecycle:information` console command.
 
-The `user-lifecycle:information` command takes one option:
-
-| Name   | Shortcut   | Description  |
-|---|---|---|
-| `username`   | `u`  | The collabUserId of the user you want to retrieve information from.  |
+The `user-lifecycle:information` command takes one argument which is the collabPersonId.
 
 Example:
 
 ```bash
-$ bin/console user-lifecycle:information --user=userid
+$ bin/console user-lifecycle:information urn:collab:example.org:user_id
 ```
 
 ## For developers

--- a/src/OpenConext/UserLifecycle/Infrastructure/UserLifecycleBundle/Command/InformationCommand.php
+++ b/src/OpenConext/UserLifecycle/Infrastructure/UserLifecycleBundle/Command/InformationCommand.php
@@ -23,8 +23,8 @@ use OpenConext\UserLifecycle\Application\Service\InformationService;
 use OpenConext\UserLifecycle\Domain\Service\InformationServiceInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class InformationCommand extends Command
@@ -56,11 +56,10 @@ class InformationCommand extends Command
                 'This command allows you to read information of a given user identified by a collabPersonId. ' .
                 'The command will ask all registered applications what information is available for the user.'
             )
-            ->addOption(
+            ->addArgument(
                 'user',
-                'u',
-                InputOption::VALUE_REQUIRED,
-                'The user identifier of the user to get information from.'
+                InputArgument::REQUIRED,
+                'The collabPersonId of the user to deprovision.'
             );
     }
 
@@ -68,7 +67,6 @@ class InformationCommand extends Command
      * Execute the information command
      *
      * The command will:
-     *  - Validate the requested user is a user of the platform, by querying the last_login data source
      *  - Retrieve information from the registered services by calling their information endpoint for the specified user
      *  - Return JSON string with the results
      *
@@ -80,7 +78,7 @@ class InformationCommand extends Command
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $userIdInput = $input->getOption('user');
+        $userIdInput = $input->getArgument('user');
         $this->logger->info(sprintf('Received an information request for user: "%s"', $userIdInput));
         try {
             $output->write($this->service->readInformationFor($userIdInput));

--- a/tests/integration/UserLifecycleBundle/Command/InformationCommandTest.php
+++ b/tests/integration/UserLifecycleBundle/Command/InformationCommandTest.php
@@ -103,7 +103,7 @@ class LastLoginRepositoryTest extends DatabaseTestCase
         $command = $this->application->find('user-lifecycle:information');
         $commandTester = new CommandTester($command);
 
-        $commandTester->execute(['--user' => $collabPersonId]);
+        $commandTester->execute(['user' => $collabPersonId]);
 
         $output = $commandTester->getDisplay();
         $this->assertContains($collabPersonId, $output);
@@ -125,13 +125,25 @@ class LastLoginRepositoryTest extends DatabaseTestCase
         $command = $this->application->find('user-lifecycle:information');
         $commandTester = new CommandTester($command);
 
-        $commandTester->execute(['--user' => $collabPersonId]);
+        $commandTester->execute(['user' => $collabPersonId]);
 
         $output = $commandTester->getDisplay();
         $this->assertContains($collabPersonId, $output);
         $this->assertContains('OK', $output);
         $this->assertContains('FAILED', $output);
         $this->assertContains($errorMessage, $output);
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Console\Exception\RuntimeException
+     * @expectedExceptionMessage Not enough arguments (missing: "user").
+     */
+    public function test_execute_no_arguments()
+    {
+        $command = $this->application->find('user-lifecycle:information');
+        $commandTester = new CommandTester($command);
+
+        $commandTester->execute([]);
     }
 
     private function getOkStatus($serviceName, $collabPersonId)


### PR DESCRIPTION
So `bin/console user-lifecycle:information --user=foobar` turns into
`bin/console user-lifecycle:information foobar`

Note the build fails on the security checker. The proposed update of Symfony is tackled in #9 . So after merging that PR, rebase this onto master and all should be well.