### PR TITLE
Don't silently drop responses if APIs use the same name

### DIFF
--- a/src/OpenConext/UserLifecycle/Domain/Client/InformationResponseCollection.php
+++ b/src/OpenConext/UserLifecycle/Domain/Client/InformationResponseCollection.php
@@ -27,7 +27,7 @@ class InformationResponseCollection implements InformationResponseCollectionInte
 
     public function addInformationResponse(InformationResponseInterface $informationResponse)
     {
-        $this->data[(string) $informationResponse->getName()] = $informationResponse;
+        $this->data[] = $informationResponse;
     }
 
     /**


### PR DESCRIPTION
If two deprovisioning APIs use the same name in the response, we don't
want the responses to be silently dropped.