### PR TITLE
Add service name to error message

### DIFF
--- a/src/OpenConext/UserLifecycle/Application/Service/SummaryService.php
+++ b/src/OpenConext/UserLifecycle/Application/Service/SummaryService.php
@@ -42,8 +42,8 @@ class SummaryService implements SummaryServiceInterface
         if (!empty($errorMessages)) {
             $errorMessageList .= sprintf(self::USER_DEPROVISION_ERROR_FORMAT).PHP_EOL.PHP_EOL;
 
-            foreach ($errorMessages as $errorMessage) {
-                $errorMessageList .= ' * '.$errorMessage.PHP_EOL;
+            foreach ($errorMessages as $serviceName => $errorMessage) {
+                $errorMessageList .= ' * '.$serviceName .': '.$errorMessage.PHP_EOL;
             }
         }
 
@@ -59,8 +59,8 @@ class SummaryService implements SummaryServiceInterface
         if (!empty($errorMessages)) {
             $errorMessageList .= sprintf(self::USER_DEPROVISION_ERROR_FORMAT).PHP_EOL.PHP_EOL;
 
-            foreach ($errorMessages as $errorMessage) {
-                $errorMessageList .= ' * '.$errorMessage.PHP_EOL;
+            foreach ($errorMessages as $serviceName => $errorMessage) {
+                $errorMessageList .= ' * '.$serviceName .': '.$errorMessage.PHP_EOL;
             }
         }
 

--- a/tests/unit/Application/Service/SummaryServiceTest.php
+++ b/tests/unit/Application/Service/SummaryServiceTest.php
@@ -67,13 +67,13 @@ class SummaryServiceTest extends TestCase
 
         $collection
             ->shouldReceive('getErrorMessages')
-            ->andReturn(['Fake error message']);
+            ->andReturn(['EngineBlock' => 'Fake error message']);
 
         $summary = $this->service->summarizeDeprovisionResponse($collection);
 
         $this->assertContains('The user was removed from 5 services.', $summary);
         $this->assertContains('See error messages below:', $summary);
-        $this->assertContains(' * Fake error message', $summary);
+        $this->assertContains(' * EngineBlock: Fake error message', $summary);
     }
 
     public function test_summarize_batch_information_collection()


### PR DESCRIPTION
In the summary above the json output. The error messages for information
and deprovision console commands are now also showing which service
errored. This was already implemented in the batch deprovision option
but not yet in information and the 'per user' deprovision commands.