### PR TITLE
Perform all requests for a single user asynchronously

### DIFF
--- a/src/OpenConext/UserLifecycle/Domain/Client/DeprovisionClientInterface.php
+++ b/src/OpenConext/UserLifecycle/Domain/Client/DeprovisionClientInterface.php
@@ -18,6 +18,7 @@
 
 namespace OpenConext\UserLifecycle\Domain\Client;
 
+use GuzzleHttp\Promise\PromiseInterface;
 use OpenConext\UserLifecycle\Domain\ValueObject\CollabPersonId;
 
 interface DeprovisionClientInterface
@@ -27,6 +28,7 @@ interface DeprovisionClientInterface
      *
      * @param CollabPersonId $user
      * @param bool $dryRun
+     * @return PromiseInterface
      */
     public function deprovision(CollabPersonId $user, $dryRun = false);
 
@@ -36,7 +38,7 @@ interface DeprovisionClientInterface
      * Returns a Json encoded string containing the user information provided by the different deprovision API's.
      *
      * @param CollabPersonId|null $user
-     * @return InformationResponseInterface
+     * @return PromiseInterface
      */
     public function information(CollabPersonId $user);
 

--- a/src/OpenConext/UserLifecycle/Domain/Client/InformationResponseFactoryInterface.php
+++ b/src/OpenConext/UserLifecycle/Domain/Client/InformationResponseFactoryInterface.php
@@ -20,5 +20,9 @@ namespace OpenConext\UserLifecycle\Domain\Client;
 
 interface InformationResponseFactoryInterface
 {
+    /**
+     * @param array $response
+     * @return InformationResponseInterface
+     */
     public function fromApiResponse(array $response);
 }

--- a/src/OpenConext/UserLifecycle/Infrastructure/UserLifecycleBundle/Client/DeprovisionClientCollection.php
+++ b/src/OpenConext/UserLifecycle/Infrastructure/UserLifecycleBundle/Client/DeprovisionClientCollection.php
@@ -18,9 +18,12 @@
 
 namespace OpenConext\UserLifecycle\Infrastructure\UserLifecycleBundle\Client;
 
+use GuzzleHttp\Promise;
+use GuzzleHttp\Promise\PromiseInterface;
 use OpenConext\UserLifecycle\Domain\Client\DeprovisionClientCollectionInterface;
 use OpenConext\UserLifecycle\Domain\Client\DeprovisionClientInterface;
 use OpenConext\UserLifecycle\Domain\Client\InformationResponseCollection;
+use OpenConext\UserLifecycle\Domain\Client\InformationResponseCollectionInterface;
 use OpenConext\UserLifecycle\Domain\ValueObject\CollabPersonId;
 
 class DeprovisionClientCollection implements DeprovisionClientCollectionInterface
@@ -30,6 +33,11 @@ class DeprovisionClientCollection implements DeprovisionClientCollectionInterfac
      */
     private $clients;
 
+    /**
+     * @param CollabPersonId $user
+     * @param bool $dryRun
+     * @return InformationResponseCollectionInterface
+     */
     public function deprovision(CollabPersonId $user, $dryRun = false)
     {
         // When dry run, only return the user information
@@ -37,26 +45,48 @@ class DeprovisionClientCollection implements DeprovisionClientCollectionInterfac
             return $this->information($user);
         }
 
-        $collection = new InformationResponseCollection();
+        $promises = [];
         foreach ($this->clients as $client) {
-            $collection->addInformationResponse($client->deprovision($user, $dryRun));
+            $promises[] = $client->deprovision($user, $dryRun);
         }
 
-        return $collection;
+        return $this->collectResponses($promises);
     }
 
+    /**
+     * @param CollabPersonId $user
+     * @return InformationResponseCollectionInterface
+     */
     public function information(CollabPersonId $user)
     {
-        $collection = new InformationResponseCollection();
+        $promises = [];
         foreach ($this->clients as $client) {
-            $collection->addInformationResponse($client->information($user));
+            $promises[] = $client->information($user);
         }
 
-        return $collection;
+        return $this->collectResponses($promises);
     }
 
     public function addClient(DeprovisionClientInterface $client)
     {
         $this->clients[$client->getName()] = $client;
+    }
+
+    /**
+     * @param PromiseInterface[] $promises
+     * @return InformationResponseCollectionInterface
+     */
+    private function collectResponses(array $promises)
+    {
+        $collection = new InformationResponseCollection();
+
+        $informationResponses = Promise\all($promises)
+            ->wait();
+
+        foreach ($informationResponses as $informationResponse) {
+            $collection->addInformationResponse($informationResponse);
+        };
+
+        return $collection;
     }
 }

--- a/src/OpenConext/UserLifecycle/Infrastructure/UserLifecycleBundle/DependencyInjection/UserLifecycleExtension.php
+++ b/src/OpenConext/UserLifecycle/Infrastructure/UserLifecycleBundle/DependencyInjection/UserLifecycleExtension.php
@@ -25,6 +25,7 @@ use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
+use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 use Webmozart\Assert\Assert;
 
@@ -114,7 +115,8 @@ class UserLifecycleExtension extends Extension
             ],
             'headers' => [
                 'Accept' => 'application/json'
-            ]
+            ],
+            'handler' => new Reference('open_conext.user_lifecycle.deprovision_client.guzzle_stack'),
         ]);
 
         $container->setDefinition(

--- a/src/OpenConext/UserLifecycle/Infrastructure/UserLifecycleBundle/Resources/config/services.yml
+++ b/src/OpenConext/UserLifecycle/Infrastructure/UserLifecycleBundle/Resources/config/services.yml
@@ -48,3 +48,14 @@ services:
 
     open_conext.user_lifecycle.deprovision_client_collection:
         class: OpenConext\UserLifecycle\Infrastructure\UserLifecycleBundle\Client\DeprovisionClientCollection
+
+    open_conext.user_lifecycle.deprovision_client.guzzle_stack:
+        public: false
+        class: 'GuzzleHttp\HandlerStack'
+        factory: ['GuzzleHttp\HandlerStack', create]
+        calls:
+            - [setHandler, ['@open_conext.user_lifecycle.deprovision_client.guzzle_handler']]
+
+    open_conext.user_lifecycle.deprovision_client.guzzle_handler:
+        public: false
+        class: 'GuzzleHttp\Handler\CurlMultiHandler'


### PR DESCRIPTION
This feature leverages GuzzleHttp promises and curl multi-exec. All
requests for deprovisioning a single user are executed
simultatiously. When all responses are processed, the requests for the
next user are sent.