### PR TITLE
Remove double summary header in deprovisioning command

### DIFF
--- a/src/OpenConext/UserLifecycle/Infrastructure/UserLifecycleBundle/Command/DeprovisionCommand.php
+++ b/src/OpenConext/UserLifecycle/Infrastructure/UserLifecycleBundle/Command/DeprovisionCommand.php
@@ -144,7 +144,6 @@ class DeprovisionCommand extends Command
 
             if (!$outputOnlyJson) {
                 $output->write($this->summaryService->summarizeBatchResponse($information), true);
-                $output->writeln('Full output of the deprovisioning command:' . PHP_EOL);
             }
 
             $output->write(json_encode($information), true);
@@ -185,7 +184,6 @@ class DeprovisionCommand extends Command
 
             if (!$outputOnlyJson) {
                 $output->write($this->summaryService->summarizeDeprovisionResponse($information), true);
-                $output->writeln('Full output of the deprovisioning command:' . PHP_EOL);
             }
 
             $output->write(json_encode($information), true);


### PR DESCRIPTION
Before:

    Full output of the deprovision command:
    Full output of the deprovisioning command:

After:

    Full output of the deprovision command: