### PR TITLE
Improve error reporting console output

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -43,9 +43,10 @@ monolog:
             path: '%kernel.logs_dir%/%kernel.environment%.log'
             level: debug
             channels: ['!event']
-#            formatter: Surfnet\ServiceProviderDashboard\Infrastructure\DashboardBundle\Monolog\Formatter\JsonFormatter
         console:
             type: console
+            verbosity_levels:
+                VERBOSITY_NORMAL: CRITICAL
             channels: ['!event', '!doctrine']
 
 user_lifecycle:

--- a/src/OpenConext/UserLifecycle/Infrastructure/UserLifecycleBundle/Command/DeprovisionCommand.php
+++ b/src/OpenConext/UserLifecycle/Infrastructure/UserLifecycleBundle/Command/DeprovisionCommand.php
@@ -18,6 +18,7 @@
 
 namespace OpenConext\UserLifecycle\Infrastructure\UserLifecycleBundle\Command;
 
+use Exception;
 use InvalidArgumentException;
 use OpenConext\UserLifecycle\Domain\Service\DeprovisionServiceInterface;
 use OpenConext\UserLifecycle\Domain\Service\SummaryServiceInterface;
@@ -147,7 +148,8 @@ class DeprovisionCommand extends Command
             }
 
             $output->write(json_encode($information), true);
-        } catch (InvalidArgumentException $e) {
+        } catch (Exception $e) {
+            $output->writeln(sprintf('<comment>%s</comment>', $e->getMessage()));
             $this->logger->error($e->getMessage());
         }
     }
@@ -187,7 +189,8 @@ class DeprovisionCommand extends Command
             }
 
             $output->write(json_encode($information), true);
-        } catch (InvalidArgumentException $e) {
+        } catch (Exception $e) {
+            $output->writeln(sprintf('<comment>%s</comment>', $e->getMessage()));
             $this->logger->error($e->getMessage());
         }
     }

--- a/src/OpenConext/UserLifecycle/Infrastructure/UserLifecycleBundle/Command/InformationCommand.php
+++ b/src/OpenConext/UserLifecycle/Infrastructure/UserLifecycleBundle/Command/InformationCommand.php
@@ -18,11 +18,10 @@
 
 namespace OpenConext\UserLifecycle\Infrastructure\UserLifecycleBundle\Command;
 
-use InvalidArgumentException;
+use Exception;
 use OpenConext\UserLifecycle\Application\Service\InformationService;
 use OpenConext\UserLifecycle\Domain\Service\InformationServiceInterface;
 use OpenConext\UserLifecycle\Domain\Service\SummaryServiceInterface;
-use OpenConext\UserLifecycle\Infrastructure\UserLifecycleBundle\Exception\RuntimeException;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
@@ -108,7 +107,8 @@ class InformationCommand extends Command
             }
 
             $output->write(json_encode($information), true);
-        } catch (InvalidArgumentException $e) {
+        } catch (Exception $e) {
+            $output->writeln(sprintf('<comment>%s</comment>', $e->getMessage()));
             $this->logger->error($e->getMessage());
         }
     }


### PR DESCRIPTION
Verbosity levels have been updated and uncaught exceptions are caught.

To reproduce the situation that caused this PR. Try to run a batch deprovision command from the console without any valid entries in your last_login table. Or create another situation where the app would log an error to the logs.

See [Pivotal](https://www.pivotaltracker.com/story/show/158139610)