### PR TITLE
Show output during batch deprovision

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ The `user` argument should be the one and only argument of the command.
 |---|---|---|
 | `--dry-run` | __none__ | Enables dry run mode, simulates a deprovision action, returning the output a regular run would, but without actually deprovisioning the user. |
 | `--json` | __none__ | Only outputs JSON. Must be used in combination with the --no-interaction option.|
+| `--pretty` | __none__ | Pretty-print JSON output.|
 | `--no-interaction` | `-n` | Prevents the confirmation question. |
 
 **Example usage**

--- a/src/OpenConext/UserLifecycle/Application/Service/ProgressReporter.php
+++ b/src/OpenConext/UserLifecycle/Application/Service/ProgressReporter.php
@@ -1,0 +1,62 @@
+<?php
+
+/**
+ * Copyright 2018 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenConext\UserLifecycle\Application\Service;
+
+use Symfony\Component\Console\Output\OutputInterface;
+
+class ProgressReporter implements ProgressReporterInterface
+{
+    /**
+     * @var OutputInterface
+     */
+    private $output;
+
+    public function setConsoleOutput(OutputInterface $output)
+    {
+        $this->output = $output;
+    }
+
+    /**
+     * @param string $message
+     * @param int $total
+     * @param int $current
+     */
+    public function progress($message, $total, $current)
+    {
+        if ($this->output === null) {
+            return;
+        }
+
+        $progress = floor($current / $total * 100);
+
+        $paddedProgress = str_pad(
+            sprintf(
+                '[%s%% of %d users]',
+                str_pad((string) $progress, 3, ' ', STR_PAD_LEFT),
+                $total
+            ),
+            20,
+            ' '
+        );
+
+        $this->output->writeln(
+            sprintf('%s %s', $paddedProgress, $message)
+        );
+    }
+}

--- a/src/OpenConext/UserLifecycle/Application/Service/ProgressReporterInterface.php
+++ b/src/OpenConext/UserLifecycle/Application/Service/ProgressReporterInterface.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * Copyright 2018 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenConext\UserLifecycle\Application\Service;
+
+use OpenConext\UserLifecycle\Domain\Service\ProgressReporterInterface as BaseProgressReporterInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+interface ProgressReporterInterface extends BaseProgressReporterInterface
+{
+    /**
+     * @param OutputInterface $output
+     */
+    public function setConsoleOutput(OutputInterface $output);
+
+    /**
+     * @param string $message
+     * @param int $total
+     * @param int $current
+     */
+    public function progress($message, $total, $current);
+}

--- a/src/OpenConext/UserLifecycle/Application/Service/SummaryService.php
+++ b/src/OpenConext/UserLifecycle/Application/Service/SummaryService.php
@@ -32,7 +32,6 @@ class SummaryService implements SummaryServiceInterface
     const USER_INFORMATION_FORMAT = 'Retrieved user information from %d %s.';
     const USER_INFORMATION_JSON_HEADING = 'Full output of the information command:';
 
-    const BATCH_DEPROVISION_FORMAT = '%d users have been deprovisioned.';
     const BATCH_DEPROVISION_ERROR_FORMAT = '%d deprovision calls to services failed. See error messages below:';
 
     public function summarizeInformationResponse(InformationResponseCollectionInterface $collection)
@@ -75,8 +74,6 @@ class SummaryService implements SummaryServiceInterface
 
     public function summarizeBatchResponse(BatchInformationResponseCollectionInterface $collection)
     {
-        $message = sprintf(self::BATCH_DEPROVISION_FORMAT, count($collection)).PHP_EOL;
-
         $errorMessageList = '';
 
         $errorMessages = $collection->getErrorMessages();
@@ -87,7 +84,7 @@ class SummaryService implements SummaryServiceInterface
             }
         }
 
-        return $message.$errorMessageList.PHP_EOL.self::USER_DEPROVISION_JSON_HEADING.PHP_EOL;
+        return $errorMessageList.PHP_EOL.self::USER_DEPROVISION_JSON_HEADING.PHP_EOL;
     }
 
     private function pluralizeService($count)

--- a/src/OpenConext/UserLifecycle/Domain/Service/DeprovisionServiceInterface.php
+++ b/src/OpenConext/UserLifecycle/Domain/Service/DeprovisionServiceInterface.php
@@ -33,8 +33,9 @@ interface DeprovisionServiceInterface
     /**
      * Finds the users marked for deprovisioning, and deprovisions them.
      *
+     * @param ProgressReporterInterface $progressReporter
      * @param bool $dryRun
      * @return BatchInformationResponseCollectionInterface
      */
-    public function batchDeprovision($dryRun = false);
+    public function batchDeprovision(ProgressReporterInterface $progressReporter, $dryRun = false);
 }

--- a/src/OpenConext/UserLifecycle/Domain/Service/ProgressReporterInterface.php
+++ b/src/OpenConext/UserLifecycle/Domain/Service/ProgressReporterInterface.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * Copyright 2018 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenConext\UserLifecycle\Domain\Service;
+
+interface ProgressReporterInterface
+{
+
+
+    /**
+     * @param string $message
+     * @param int $total
+     * @param int $current
+     */
+    public function progress($message, $total, $current);
+}

--- a/src/OpenConext/UserLifecycle/Infrastructure/UserLifecycleBundle/Resources/config/services.yml
+++ b/src/OpenConext/UserLifecycle/Infrastructure/UserLifecycleBundle/Resources/config/services.yml
@@ -34,6 +34,7 @@ services:
         arguments:
             - '@OpenConext\UserLifecycle\Application\Service\DeprovisionService'
             - '@OpenConext\UserLifecycle\Application\Service\SummaryService'
+            - '@OpenConext\UserLifecycle\Application\Service\ProgressReporter'
             - '@logger'
         tags:
             - 'console.command'

--- a/tests/integration/UserLifecycleBundle/Command/BatchDeprovisionCommandTest.php
+++ b/tests/integration/UserLifecycleBundle/Command/BatchDeprovisionCommandTest.php
@@ -23,6 +23,7 @@ use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\Psr7\Response;
 use Mockery as m;
 use OpenConext\UserLifecycle\Application\Service\DeprovisionService;
+use OpenConext\UserLifecycle\Application\Service\ProgressReporter;
 use OpenConext\UserLifecycle\Application\Service\SummaryService;
 use OpenConext\UserLifecycle\Domain\Entity\LastLogin;
 use OpenConext\UserLifecycle\Infrastructure\UserLifecycleBundle\Command\DeprovisionCommand;
@@ -97,7 +98,9 @@ class BatchDeprovisionCommandTest extends DatabaseTestCase
         $logger = m::mock(LoggerInterface::class);
         $logger->shouldIgnoreMissing();
 
-        $this->application->add(new DeprovisionCommand($deprovisionService, $summaryService, $logger));
+        $progressReporter = new ProgressReporter();
+
+        $this->application->add(new DeprovisionCommand($deprovisionService, $summaryService, $progressReporter, $logger));
 
         // Load the database fixtures
         $this->loadFixtures();

--- a/tests/integration/UserLifecycleBundle/Command/DeprovisionCommandTest.php
+++ b/tests/integration/UserLifecycleBundle/Command/DeprovisionCommandTest.php
@@ -23,6 +23,7 @@ use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\Psr7\Response;
 use Mockery as m;
 use OpenConext\UserLifecycle\Application\Service\DeprovisionService;
+use OpenConext\UserLifecycle\Application\Service\ProgressReporter;
 use OpenConext\UserLifecycle\Application\Service\SummaryService;
 use OpenConext\UserLifecycle\Domain\Entity\LastLogin;
 use OpenConext\UserLifecycle\Infrastructure\UserLifecycleBundle\Command\DeprovisionCommand;
@@ -96,7 +97,9 @@ class DeprovisionCommandTest extends DatabaseTestCase
         $logger = m::mock(LoggerInterface::class);
         $logger->shouldIgnoreMissing();
 
-        $this->application->add(new DeprovisionCommand($deprovisionService, $summaryService, $logger));
+        $progressReporter = new ProgressReporter();
+
+        $this->application->add(new DeprovisionCommand($deprovisionService, $summaryService, $progressReporter, $logger));
 
         // Load the database fixtures
         $this->loadFixtures();

--- a/tests/unit/Application/Service/DeprovisionServiceTest.php
+++ b/tests/unit/Application/Service/DeprovisionServiceTest.php
@@ -28,6 +28,7 @@ use OpenConext\UserLifecycle\Domain\Client\InformationResponseCollectionInterfac
 use OpenConext\UserLifecycle\Domain\Collection\LastLoginCollectionInterface;
 use OpenConext\UserLifecycle\Domain\Entity\LastLogin;
 use OpenConext\UserLifecycle\Domain\Service\LastLoginServiceInterface;
+use OpenConext\UserLifecycle\Domain\Service\ProgressReporterInterface;
 use OpenConext\UserLifecycle\Domain\Service\RemovalCheckServiceInterface;
 use OpenConext\UserLifecycle\Domain\Service\SanityCheckServiceInterface;
 use OpenConext\UserLifecycle\Infrastructure\UserLifecycleBundle\Client\DeprovisionClientCollection;
@@ -173,6 +174,10 @@ class DeprovisionServiceTest extends TestCase
             ->shouldReceive('getData')
             ->andReturn([$mockUser1, $mockUser2]);
 
+        $mockCollection
+            ->shouldReceive('count')
+            ->andReturn(2);
+
         $collection = m::mock(InformationResponseCollectionInterface::class);
         $collection
             ->shouldReceive('jsonSerialize')
@@ -198,7 +203,12 @@ class DeprovisionServiceTest extends TestCase
             ->shouldReceive('handle')
             ->twice();
 
-        $this->service->batchDeprovision();
+        $progressReporter = m::mock(ProgressReporterInterface::class);
+        $progressReporter->shouldReceive('setConsoleOutput');
+        $progressReporter->shouldReceive('progress')
+            ->times(3);
+
+        $this->service->batchDeprovision($progressReporter);
     }
 
     public function test_batch_deprovision_dry_run()
@@ -220,6 +230,10 @@ class DeprovisionServiceTest extends TestCase
             ->shouldReceive('getData')
             ->andReturn([$mockUser1, $mockUser2]);
 
+        $mockCollection
+            ->shouldReceive('count')
+            ->andReturn(2);
+
         $collection = m::mock(InformationResponseCollectionInterface::class);
         $collection
             ->shouldReceive('jsonSerialize')
@@ -236,7 +250,13 @@ class DeprovisionServiceTest extends TestCase
                 }
             );
 
-        $this->service->batchDeprovision(true);
+
+        $progressReporter = m::mock(ProgressReporterInterface::class);
+        $progressReporter->shouldReceive('setConsoleOutput');
+        $progressReporter->shouldReceive('progress')
+            ->times(3);
+
+        $this->service->batchDeprovision($progressReporter, true);
     }
 
     private function buildMockLastLoginEntry($personId)

--- a/tests/unit/Application/Service/ProgressReporterTest.php
+++ b/tests/unit/Application/Service/ProgressReporterTest.php
@@ -1,0 +1,64 @@
+<?php
+
+/**
+ * Copyright 2018 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenConext\UserLifecycle\Tests\Unit\Application\Service;
+
+use Mockery as m;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use OpenConext\UserLifecycle\Application\Service\ProgressReporter;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class ProgressReporterTest extends TestCase
+{
+    use MockeryPHPUnitIntegration;
+
+    public function test_reporter_does_nothing_without_console_output_object()
+    {
+        $reporter = new ProgressReporter();
+        $this->assertNull(
+            $reporter->progress('test', 1, 100)
+        );
+    }
+
+    public function test_reporter_prints_progress_to_console()
+    {
+        $output = m::mock(OutputInterface::class);
+        $output
+            ->shouldReceive('writeln')
+            ->with('[  0% of 4 users]    test');
+
+        $output
+            ->shouldReceive('writeln')
+            ->with('[ 50% of 4 users]    test');
+
+        $output
+            ->shouldReceive('writeln')
+            ->with('[100% of 4 users]    test');
+
+        $reporter = new ProgressReporter();
+        $reporter->setConsoleOutput($output);
+
+        $reporter->progress('test', 4, 0);
+        $reporter->progress('test', 4, 2);
+
+        $this->assertNull(
+            $reporter->progress('test', 4, 4)
+        );
+    }
+}

--- a/tests/unit/Application/Service/SummaryServiceTest.php
+++ b/tests/unit/Application/Service/SummaryServiceTest.php
@@ -89,7 +89,6 @@ class SummaryServiceTest extends TestCase
 
         $summary = $this->service->summarizeBatchResponse($collection);
 
-        $this->assertContains('256 users have been deprovisioned.', $summary);
         $this->assertNotContains('See error messages below:', $summary);
     }
 
@@ -110,7 +109,6 @@ class SummaryServiceTest extends TestCase
 
         $summary = $this->service->summarizeBatchResponse($collection);
 
-        $this->assertContains('256 users have been deprovisioned.', $summary);
         $this->assertContains('3 deprovision calls to services failed. See error messages below:', $summary);
         $this->assertContains(' * Service name: "Error message" for user "collabPersonId"', $summary);
         $this->assertContains(' * EngineBlock: "Service not available" for user "urn:collab:jane_doe"', $summary);


### PR DESCRIPTION
Example output, only shown without --json-only:

    [  0% of 3 users]    Working on urn:collab:person:example.com:admin...
    [ 33% of 3 users]    Working on urn:collab:person:example.com:admin2...
    [ 66% of 3 users]    Working on urn:collab:person:example.com:admin3...
    [100% of 3 users]    Done.

See https://www.pivotaltracker.com/story/show/158107568