### PR TITLE
Enable health endpoint whithout authentication

### DIFF
--- a/app/config/routing.yml
+++ b/app/config/routing.yml
@@ -1,2 +1,6 @@
 dashboard:
     resource: '@UserLifecycleBundle/Resources/config/routing.yml'
+
+openconext_monitor:
+  resource: "@OpenConextMonitorBundle/Resources/config/routing.yml"
+  prefix: /

--- a/app/config/security.yml
+++ b/app/config/security.yml
@@ -19,6 +19,10 @@ security:
             pattern: ^/(_(profiler|wdt)|css|images|js)/
             security: false
 
+        monitor:
+            pattern: ^/(info|health)$
+            security: false
+
         main:
             anonymous: ~
             http_basic: ~


### PR DESCRIPTION
The health endpoints were added but not enabled. The endpoints however
need to be enabled in order to take into production.