### PR TITLE
Improve CollabPersonId input validation

### DIFF
--- a/src/OpenConext/UserLifecycle/Domain/ValueObject/CollabPersonId.php
+++ b/src/OpenConext/UserLifecycle/Domain/ValueObject/CollabPersonId.php
@@ -22,6 +22,8 @@ use OpenConext\UserLifecycle\Domain\Exception\InvalidCollabPersonIdException;
 
 class CollabPersonId
 {
+    private static $pattern = '/^urn:collab:person:.+$/';
+
     /**
      * @var string
      */
@@ -33,9 +35,11 @@ class CollabPersonId
             $collabUserId = trim($collabUserId);
         }
         if (empty($collabUserId) || !is_string($collabUserId)) {
-            throw new InvalidCollabPersonIdException('The collabUserId must be a non empty string');
+            throw new InvalidCollabPersonIdException('The collabPersonId must be a non empty string');
         }
-
+        if (preg_match(self::$pattern, $collabUserId) !== 1) {
+            throw new InvalidCollabPersonIdException('The collabPersonId must start with urn:collab:person:');
+        }
         $this->collabPersonId = $collabUserId;
     }
 

--- a/tests/unit/Domain/ValueObject/CollabPersonIdTest.php
+++ b/tests/unit/Domain/ValueObject/CollabPersonIdTest.php
@@ -27,10 +27,10 @@ class CollabPersonIdTest extends TestCase
 {
     use MockeryPHPUnitIntegration;
 
-    public function test_can_be_created()
+    public function test_can_be_created(): void
     {
-        $user = new CollabPersonId('urn:mace:example.com:jan');
-        $this->assertEquals('urn:mace:example.com:jan', $user->getCollabPersonId());
+        $user = new CollabPersonId('urn:collab:person:institution-a:jan');
+        $this->assertEquals('urn:collab:person:institution-a:jan', $user->getCollabPersonId());
     }
 
     /**
@@ -40,7 +40,18 @@ class CollabPersonIdTest extends TestCase
     public function test_must_be_non_empty_string($invalidArgument)
     {
         $this->expectException(InvalidCollabPersonIdException::class);
-        $this->expectExceptionMessage('The collabUserId must be a non empty string');
+        $this->expectExceptionMessage('The collabPersonId must be a non empty string');
+
+        new CollabPersonId($invalidArgument);
+    }
+
+    /**
+     * @dataProvider invalidUrnCollabPersonIds
+     */
+    public function test_only_urn_collab_person_id_prefixed_ids_are_allowed(string $invalidArgument): void
+    {
+        $this->expectException(InvalidCollabPersonIdException::class);
+        $this->expectExceptionMessage('The collabPersonId must start with urn:collab:person:');
 
         new CollabPersonId($invalidArgument);
     }
@@ -54,6 +65,20 @@ class CollabPersonIdTest extends TestCase
             [null],
             [true],
             [['urn:mace:example.com:jan']]
+        ];
+    }
+
+    public function invalidUrnCollabPersonIds()
+    {
+        return [
+            ['collab:person:jan'],
+            ['urn:person:jan'],
+            ['urn:mace:example.com:jan'],
+            ['urn:collab:personid:org:username'],
+            ['urn:colab:person:org:username'],
+            ['urn:collab:person'],
+            ['urn:collab:person:'],
+            ['urn:collab:person-org:jesse'],
         ];
     }
 }


### PR DESCRIPTION
An additional check was added to ensure the collabPersonId starts with the well known prefix: `urn:collab:person:`.

See https://www.pivotaltracker.com/story/show/158028385