### PR TITLE
Improve error reporting

### DIFF
--- a/src/OpenConext/UserLifecycle/Application/Service/DeprovisionService.php
+++ b/src/OpenConext/UserLifecycle/Application/Service/DeprovisionService.php
@@ -24,6 +24,7 @@ use OpenConext\UserLifecycle\Domain\Client\BatchInformationResponseCollection;
 use OpenConext\UserLifecycle\Domain\Client\BatchInformationResponseCollectionInterface;
 use OpenConext\UserLifecycle\Domain\Client\DeprovisionClientCollectionInterface;
 use OpenConext\UserLifecycle\Domain\Client\InformationResponseCollectionInterface;
+use OpenConext\UserLifecycle\Domain\Service\ClientHealthCheckerInterface;
 use OpenConext\UserLifecycle\Domain\Service\DeprovisionServiceInterface;
 use OpenConext\UserLifecycle\Domain\Service\LastLoginServiceInterface;
 use OpenConext\UserLifecycle\Domain\Service\ProgressReporterInterface;
@@ -36,7 +37,7 @@ use Webmozart\Assert\Assert;
 /**
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  */
-class DeprovisionService implements DeprovisionServiceInterface
+class DeprovisionService implements DeprovisionServiceInterface, ClientHealthCheckerInterface
 {
     /**
      * @var DeprovisionClientCollectionInterface
@@ -96,7 +97,6 @@ class DeprovisionService implements DeprovisionServiceInterface
         $collabPersonId = $this->buildCollabPersonId($personId);
 
         $this->logger->debug('Delegate deprovisioning to the registered services.');
-
         $information = $this->deprovisionClientCollection->deprovision($collabPersonId, $dryRun);
 
         $this->logger->info(
@@ -126,7 +126,6 @@ class DeprovisionService implements DeprovisionServiceInterface
         $users = $this->lastLoginService->findUsersForDeprovision();
         $this->logger->debug('Perform sanity checks on the response from the last login service.');
         $this->sanityCheckService->check($users);
-
         $batchInformationCollection = new BatchInformationResponseCollection();
 
         foreach ($users->getData() as $currentIndex => $lastLogin) {
@@ -165,5 +164,10 @@ class DeprovisionService implements DeprovisionServiceInterface
         Assert::stringNotEmpty($personId, 'Please pass a non empty collabPersonId');
 
         return new CollabPersonId($personId);
+    }
+
+    public function healthCheck(): void
+    {
+        $this->deprovisionClientCollection->healthCheck();
     }
 }

--- a/src/OpenConext/UserLifecycle/Application/Service/DeprovisionService.php
+++ b/src/OpenConext/UserLifecycle/Application/Service/DeprovisionService.php
@@ -124,7 +124,6 @@ class DeprovisionService implements DeprovisionServiceInterface
     {
         $this->logger->debug('Retrieve the users that are marked for deprovisioning.');
         $users = $this->lastLoginService->findUsersForDeprovision();
-
         $this->logger->debug('Perform sanity checks on the response from the last login service.');
         $this->sanityCheckService->check($users);
 

--- a/src/OpenConext/UserLifecycle/Application/Service/InformationService.php
+++ b/src/OpenConext/UserLifecycle/Application/Service/InformationService.php
@@ -21,15 +21,16 @@ namespace OpenConext\UserLifecycle\Application\Service;
 use InvalidArgumentException;
 use OpenConext\UserLifecycle\Domain\Client\DeprovisionClientCollectionInterface;
 use OpenConext\UserLifecycle\Domain\Client\InformationResponseCollectionInterface;
+use OpenConext\UserLifecycle\Domain\Service\ClientHealthCheckerInterface;
 use OpenConext\UserLifecycle\Domain\Service\InformationServiceInterface;
 use OpenConext\UserLifecycle\Domain\ValueObject\CollabPersonId;
 use Psr\Log\LoggerInterface;
 use Webmozart\Assert\Assert;
 
-class InformationService implements InformationServiceInterface
+class InformationService implements InformationServiceInterface, ClientHealthCheckerInterface
 {
     /**
-     * @var DeprovisionClientCollectionInterface
+     * @var DeprovisionClientCollectionInterface&ClientHealthCheckerInterface
      */
     private $deprovisionClientCollection;
 
@@ -58,7 +59,6 @@ class InformationService implements InformationServiceInterface
         Assert::stringNotEmpty($personId, 'Please pass a non empty collabPersonId');
 
         $collabPersonId = new CollabPersonId($personId);
-
         $this->logger->debug('Retrieve the information from the APIs for the user.');
         $information = $this->deprovisionClientCollection->information($collabPersonId);
 
@@ -68,5 +68,9 @@ class InformationService implements InformationServiceInterface
         );
 
         return $information;
+    }
+    public function healthCheck(): void
+    {
+        $this->deprovisionClientCollection->healthCheck();
     }
 }

--- a/src/OpenConext/UserLifecycle/Domain/Client/DeprovisionClientInterface.php
+++ b/src/OpenConext/UserLifecycle/Domain/Client/DeprovisionClientInterface.php
@@ -25,27 +25,20 @@ interface DeprovisionClientInterface
 {
     /**
      * Can be used to deprovision a user from the OpenConext platform.
-     *
-     * @param CollabPersonId $user
-     * @param bool $dryRun
-     * @return PromiseInterface
      */
-    public function deprovision(CollabPersonId $user, $dryRun = false);
+    public function deprovision(CollabPersonId $user, bool $dryRun = false): PromiseInterface;
 
     /**
      * Can be used to gather information about a user on the OpenConext platform.
      *
      * Returns a Json encoded string containing the user information provided by the different deprovision API's.
-     *
-     * @param CollabPersonId|null $user
-     * @return PromiseInterface
      */
-    public function information(CollabPersonId $user);
+    public function information(CollabPersonId $user): PromiseInterface;
 
     /**
      * Returns the name of the client, as configured in the parameters.yml
-     *
-     * @return string
      */
-    public function getName();
+    public function getName(): string;
+
+    public function health(): void;
 }

--- a/src/OpenConext/UserLifecycle/Domain/Exception/DeprovisionClientUnavailableException.php
+++ b/src/OpenConext/UserLifecycle/Domain/Exception/DeprovisionClientUnavailableException.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * Copyright 2022 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenConext\UserLifecycle\Domain\Exception;
+
+use RuntimeException;
+use Throwable;
+
+class DeprovisionClientUnavailableException extends RuntimeException
+{
+    public function __construct(string $clientName, $code = 0, Throwable $previous = null)
+    {
+        $message = sprintf("Connection failed to backend '%s'", $clientName);
+        parent::__construct($message, $code, $previous);
+    }
+}

--- a/src/OpenConext/UserLifecycle/Domain/Service/ClientHealthCheckerInterface.php
+++ b/src/OpenConext/UserLifecycle/Domain/Service/ClientHealthCheckerInterface.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Copyright 2018 SURFnet B.V.
+ * Copyright 2022 SURFnet B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,31 +16,14 @@
  * limitations under the License.
  */
 
-namespace OpenConext\UserLifecycle\Domain\Client;
+namespace OpenConext\UserLifecycle\Domain\Service;
 
 use OpenConext\UserLifecycle\Domain\Exception\DeprovisionClientUnavailableException;
-use OpenConext\UserLifecycle\Domain\ValueObject\CollabPersonId;
 
-interface DeprovisionClientCollectionInterface
+interface ClientHealthCheckerInterface
 {
-    public function addClient(DeprovisionClientInterface $client);
-
-    /**
-     * @param CollabPersonId $user
-     * @param bool $dryRun
-     *
-     * @return InformationResponseCollectionInterface
-     */
-    public function deprovision(CollabPersonId $user, $dryRun = false);
-
-    /**
-     * @param CollabPersonId $user
-     * @return InformationResponseCollectionInterface
-     */
-    public function information(CollabPersonId $user);
-
     /**
      * @throws DeprovisionClientUnavailableException
      */
-    public function healthCheck();
+    public function healthCheck(): void;
 }

--- a/src/OpenConext/UserLifecycle/Infrastructure/UserLifecycleBundle/Client/DeprovisionClientCollection.php
+++ b/src/OpenConext/UserLifecycle/Infrastructure/UserLifecycleBundle/Client/DeprovisionClientCollection.php
@@ -24,6 +24,7 @@ use OpenConext\UserLifecycle\Domain\Client\DeprovisionClientCollectionInterface;
 use OpenConext\UserLifecycle\Domain\Client\DeprovisionClientInterface;
 use OpenConext\UserLifecycle\Domain\Client\InformationResponseCollection;
 use OpenConext\UserLifecycle\Domain\Client\InformationResponseCollectionInterface;
+use OpenConext\UserLifecycle\Domain\Exception\DeprovisionClientUnavailableException;
 use OpenConext\UserLifecycle\Domain\ValueObject\CollabPersonId;
 
 class DeprovisionClientCollection implements DeprovisionClientCollectionInterface
@@ -80,8 +81,15 @@ class DeprovisionClientCollection implements DeprovisionClientCollectionInterfac
 
         foreach ($informationResponses as $informationResponse) {
             $collection->addInformationResponse($informationResponse);
-        };
+        }
 
         return $collection;
+    }
+
+    public function healthCheck()
+    {
+        foreach ($this->clients as $client) {
+            $client->health();
+        }
     }
 }

--- a/src/OpenConext/UserLifecycle/Infrastructure/UserLifecycleBundle/Command/DeprovisionCommand.php
+++ b/src/OpenConext/UserLifecycle/Infrastructure/UserLifecycleBundle/Command/DeprovisionCommand.php
@@ -21,6 +21,7 @@ namespace OpenConext\UserLifecycle\Infrastructure\UserLifecycleBundle\Command;
 use Exception;
 use JsonSerializable;
 use OpenConext\UserLifecycle\Application\Service\ProgressReporterInterface;
+use OpenConext\UserLifecycle\Domain\Service\ClientHealthCheckerInterface;
 use OpenConext\UserLifecycle\Domain\Service\DeprovisionServiceInterface;
 use OpenConext\UserLifecycle\Domain\Service\SummaryServiceInterface;
 use OpenConext\UserLifecycle\Infrastructure\UserLifecycleBundle\Exception\RuntimeException;
@@ -40,7 +41,7 @@ class DeprovisionCommand extends Command
     private $logger;
 
     /**
-     * @var DeprovisionServiceInterface
+     * @var DeprovisionServiceInterface&ClientHealthCheckerInterface
      */
     private $service;
 
@@ -174,6 +175,8 @@ class DeprovisionCommand extends Command
         }
 
         try {
+            $this->logger->debug('Health check the remote services.');
+            $this->service->healthCheck();
             $information = $this->service->batchDeprovision($this->progressReporter, $dryRun);
 
             if (!$outputOnlyJson) {
@@ -219,6 +222,8 @@ class DeprovisionCommand extends Command
             )
         );
         try {
+            $this->logger->debug('Health check the remote services.');
+            $this->service->healthCheck();
             $information = $this->service->deprovision($userIdInput, $dryRun);
 
             if (!$outputOnlyJson) {

--- a/src/OpenConext/UserLifecycle/Infrastructure/UserLifecycleBundle/Command/InformationCommand.php
+++ b/src/OpenConext/UserLifecycle/Infrastructure/UserLifecycleBundle/Command/InformationCommand.php
@@ -20,6 +20,7 @@ namespace OpenConext\UserLifecycle\Infrastructure\UserLifecycleBundle\Command;
 
 use Exception;
 use OpenConext\UserLifecycle\Application\Service\InformationService;
+use OpenConext\UserLifecycle\Domain\Service\ClientHealthCheckerInterface;
 use OpenConext\UserLifecycle\Domain\Service\InformationServiceInterface;
 use OpenConext\UserLifecycle\Domain\Service\SummaryServiceInterface;
 use Psr\Log\LoggerInterface;
@@ -37,7 +38,7 @@ class InformationCommand extends Command
     private $logger;
 
     /**
-     * @var InformationService
+     * @var InformationService&ClientHealthCheckerInterface
      */
     private $service;
 
@@ -103,6 +104,8 @@ class InformationCommand extends Command
         $this->logger->info(sprintf('Received an information request for user: "%s"', $userIdInput));
 
         try {
+            $this->logger->debug('Health check the remote services.');
+            $this->service->healthCheck();
             $information = $this->service->readInformationFor($userIdInput);
 
             if (!$outputOnlyJson) {

--- a/src/OpenConext/UserLifecycle/Infrastructure/UserLifecycleBundle/Exception/DatabaseConnectionException.php
+++ b/src/OpenConext/UserLifecycle/Infrastructure/UserLifecycleBundle/Exception/DatabaseConnectionException.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * Copyright 2022 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenConext\UserLifecycle\Infrastructure\UserLifecycleBundle\Exception;
+
+use JetBrains\PhpStorm\Internal\LanguageLevelTypeAware;
+use RuntimeException as CoreRuntimeException;
+
+class DatabaseConnectionException extends CoreRuntimeException
+{
+    public function __construct(
+        $message = "No connection possible to the database",
+        $code = 0,
+        Throwable $previous = null
+    ) {
+        parent::__construct($message, $code, $previous);
+    }
+}

--- a/tests/integration/UserLifecycleBundle/Command/BatchDeprovisionCommandTest.php
+++ b/tests/integration/UserLifecycleBundle/Command/BatchDeprovisionCommandTest.php
@@ -117,10 +117,12 @@ class BatchDeprovisionCommandTest extends DatabaseTestCase
 
         $collabPersonId = 'urn:collab:person:surf.nl:jimi_hendrix';
         $this->handlerMyService->append(
+            new Response(200, [], '{"status":"UP"}'),
             new Response(200, [], $this->getOkStatus('my_service_name', $collabPersonId))
         );
 
         $this->handlerMySecondService->append(
+            new Response(200, [], '{"status":"UP"}'),
             new Response(200, [], $this->getOkStatus('my_second_name', $collabPersonId))
         );
 
@@ -148,6 +150,7 @@ class BatchDeprovisionCommandTest extends DatabaseTestCase
         $this->assertCount(4, $this->repository->findAll());
 
         $this->handlerMyService->append(
+            new Response(200, [], '{"status":"UP"}'),
             new Response(200, [], $this->getOkStatus('my_service_name', 'urn:collab:person:user1')),
             new Response(200, [], $this->getOkStatus('my_service_name', 'urn:collab:person:user2')),
             new Response(200, [], $this->getOkStatus('my_service_name', 'urn:collab:person:user3')),
@@ -155,6 +158,7 @@ class BatchDeprovisionCommandTest extends DatabaseTestCase
         );
 
         $this->handlerMySecondService->append(
+            new Response(200, [], '{"status":"UP"}'),
             new Response(200, [], $this->getOkStatus('my_second_name', 'urn:collab:person:user1')),
             new Response(200, [], $this->getOkStatus('my_second_name', 'urn:collab:person:user2')),
             new Response(200, [], $this->getOkStatus('my_second_name', 'urn:collab:person:user3')),
@@ -179,6 +183,7 @@ class BatchDeprovisionCommandTest extends DatabaseTestCase
         $this->assertCount(4, $this->repository->findAll());
 
         $this->handlerMyService->append(
+            new Response(200, [], '{"status":"UP"}'),
             new Response(200, [], $this->getOkStatus('my_service_name', 'urn:collab:person:user1')),
             new Response(200, [], $this->getOkStatus('my_service_name', 'urn:collab:person:user2')),
             new Response(200, [], $this->getOkStatus('my_service_name', 'urn:collab:person:user3')),
@@ -186,6 +191,7 @@ class BatchDeprovisionCommandTest extends DatabaseTestCase
         );
 
         $this->handlerMySecondService->append(
+            new Response(200, [], '{"status":"UP"}'),
             new Response(200, [], $this->getOkStatus('my_second_name', 'urn:collab:person:user1')),
             new Response(200, [], $this->getOkStatus('my_second_name', 'urn:collab:person:user2')),
             new Response(200, [], $this->getFailedStatus('my_second_name', 'urn:collab:person:user3')),

--- a/tests/integration/UserLifecycleBundle/Command/DeprovisionCommandTest.php
+++ b/tests/integration/UserLifecycleBundle/Command/DeprovisionCommandTest.php
@@ -115,10 +115,12 @@ class DeprovisionCommandTest extends DatabaseTestCase
         $collabPersonId = 'urn:collab:person:surf.nl:jimi_hendrix';
 
         $this->handlerMyService->append(
+            new Response(200, [], '{"status":"UP"}'),
             new Response(200, [], $this->getOkStatus('my_service_name', $collabPersonId))
         );
 
         $this->handlerMySecondService->append(
+            new Response(200, [], '{"status":"UP"}'),
             new Response(200, [], $this->getOkStatus('my_second_name', $collabPersonId))
         );
 
@@ -141,10 +143,12 @@ class DeprovisionCommandTest extends DatabaseTestCase
         $collabPersonId = 'urn:collab:person:surf.nl:jimi_hendrix';
 
         $this->handlerMyService->append(
+            new Response(200, [], '{"status":"UP"}'),
             new Response(200, [], $this->getOkStatus('my_service_name', $collabPersonId))
         );
 
         $this->handlerMySecondService->append(
+            new Response(200, [], '{"status":"UP"}'),
             new Response(200, [], $this->getOkStatus('my_second_name', $collabPersonId))
         );
 
@@ -167,10 +171,12 @@ class DeprovisionCommandTest extends DatabaseTestCase
         $collabPersonId = 'urn:collab:person:surf.nl:jimi_hendrix';
 
         $this->handlerMyService->append(
+            new Response(200, [], '{"status":"UP"}'),
             new Response(200, [], $this->getOkStatus('my_service_name', $collabPersonId))
         );
 
         $this->handlerMySecondService->append(
+            new Response(200, [], '{"status":"UP"}'),
             new Response(200, [], $this->getOkStatus('my_second_name', $collabPersonId))
         );
 
@@ -192,10 +198,12 @@ class DeprovisionCommandTest extends DatabaseTestCase
         $collabPersonId = 'urn:collab:person:surf.nl:jimi_hendrix';
 
         $this->handlerMyService->append(
+            new Response(200, [], '{"status":"UP"}'),
             new Response(200, [], $this->getOkStatus('my_service_name', $collabPersonId))
         );
 
         $this->handlerMySecondService->append(
+            new Response(200, [], '{"status":"UP"}'),
             new Response(200, [], $this->getOkStatus('my_second_name', $collabPersonId))
         );
 
@@ -216,10 +224,12 @@ class DeprovisionCommandTest extends DatabaseTestCase
         $collabPersonId = 'urn:collab:person:surf.nl:jimi_hendrix';
 
         $this->handlerMyService->append(
+            new Response(200, [], '{"status":"UP"}'),
             new Response(200, [], $this->getOkStatus('my_service_name', $collabPersonId))
         );
 
         $this->handlerMySecondService->append(
+            new Response(200, [], '{"status":"UP"}'),
             new Response(200, [], $this->getOkStatus('my_second_name', $collabPersonId))
         );
 

--- a/tests/integration/UserLifecycleBundle/Command/InformationCommandTest.php
+++ b/tests/integration/UserLifecycleBundle/Command/InformationCommandTest.php
@@ -95,10 +95,12 @@ class LastLoginRepositoryTest extends DatabaseTestCase
         $collabPersonId = 'urn:collab:person:surf.nl:jimi_hendrix';
 
         $this->handlerMyService->append(
+            new Response(200, [], '{"status":"UP"}'),
             new Response(200, [], $this->getOkStatus('my_service_name', $collabPersonId))
         );
 
         $this->handlerMySecondService->append(
+            new Response(200, [], '{"status":"UP"}'),
             new Response(200, [], $this->getOkStatus('my_second_name', $collabPersonId))
         );
 
@@ -117,11 +119,13 @@ class LastLoginRepositoryTest extends DatabaseTestCase
         $collabPersonId = 'urn:collab:person:surf.nl:jimi_hendrix';
 
         $this->handlerMyService->append(
+            new Response(200, [], '{"status":"UP"}'),
             new Response(200, [], $this->getOkStatus('my_service_name', $collabPersonId))
         );
 
         $errorMessage = 'Internal server error';
         $this->handlerMySecondService->append(
+            new Response(200, [], '{"status":"UP"}'),
             new Response(200, [], $this->getFailedStatus('my_second_name', $errorMessage))
         );
         $command = $this->application->find('information');
@@ -151,11 +155,13 @@ class LastLoginRepositoryTest extends DatabaseTestCase
         $collabPersonId = 'urn:collab:person:surf.nl:jimi_hendrix';
 
         $this->handlerMyService->append(
+            new Response(200, [], '{"status":"UP"}'),
             new Response(200, [], $this->getOkStatus('my_service_name', $collabPersonId))
         );
 
         $errorMessage = 'Internal server error';
         $this->handlerMySecondService->append(
+            new Response(200, [], '{"status":"UP"}'),
             new Response(200, [], $this->getFailedStatus('my_second_name', $errorMessage))
         );
         $command = $this->application->find('information');

--- a/tests/unit/Application/Service/DeprovisionServiceTest.php
+++ b/tests/unit/Application/Service/DeprovisionServiceTest.php
@@ -27,6 +27,7 @@ use OpenConext\UserLifecycle\Application\Service\DeprovisionService;
 use OpenConext\UserLifecycle\Domain\Client\InformationResponseCollectionInterface;
 use OpenConext\UserLifecycle\Domain\Collection\LastLoginCollectionInterface;
 use OpenConext\UserLifecycle\Domain\Entity\LastLogin;
+use OpenConext\UserLifecycle\Domain\Service\DeprovisionClientHealthCheckerInterface;
 use OpenConext\UserLifecycle\Domain\Service\LastLoginServiceInterface;
 use OpenConext\UserLifecycle\Domain\Service\ProgressReporterInterface;
 use OpenConext\UserLifecycle\Domain\Service\RemovalCheckServiceInterface;
@@ -71,7 +72,12 @@ class DeprovisionServiceTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->apiCollection = m::mock(DeprovisionClientCollection::class);
+        $this->apiCollection = m::mock(
+            DeprovisionClientCollection::class,
+            DeprovisionClientHealthCheckerInterface::class
+        );
+        $this->apiCollection
+            ->shouldReceive('healthCheck');
         $this->sanityChecker = m::mock(SanityCheckServiceInterface::class);
         $this->lastLoginService = m::mock(LastLoginServiceInterface::class);
         $this->removalCheckService = m::mock(RemovalCheckServiceInterface::class);

--- a/tests/unit/Application/Service/InformationServiceTest.php
+++ b/tests/unit/Application/Service/InformationServiceTest.php
@@ -25,6 +25,8 @@ use Mockery\Mock;
 use OpenConext\UserLifecycle\Application\Service\InformationService;
 use OpenConext\UserLifecycle\Domain\Client\DeprovisionClientCollectionInterface;
 use OpenConext\UserLifecycle\Domain\Client\InformationResponseCollection;
+use OpenConext\UserLifecycle\Domain\Service\DeprovisionClientHealthCheckerInterface;
+use OpenConext\UserLifecycle\Infrastructure\UserLifecycleBundle\Client\DeprovisionClientCollection;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 
@@ -44,7 +46,12 @@ class InformationServiceTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->apiCollection = m::mock(DeprovisionClientCollectionInterface::class);
+        $this->apiCollection = m::mock(
+            DeprovisionClientCollection::class,
+            DeprovisionClientHealthCheckerInterface::class
+        );
+        $this->apiCollection
+            ->shouldReceive('healthCheck');
         $logger = m::mock(LoggerInterface::class)->shouldIgnoreMissing();
         $this->service = new InformationService($this->apiCollection, $logger);
     }


### PR DESCRIPTION
When an application error occurs, the output of the deprovision/info commands are not always that great. To improve on this. The most common error situations are now covered more closely in assertions. This ensures we can show custom error messages.

Checks of task 3 of https://www.pivotaltracker.com/story/show/176168526