### PR TITLE
Fix Unit tests to comply to stricter CollabPersonId validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ The `user` argument should be the one and only argument of the command.
 **Example usage**
 
 ```bash
-$ userlifecyle deprovision urn:collab:org:surf.nl:janis_joplin
-Continue with deprovisioning of "urn:collab:org:surf.nl:janis_joplin"? (y/n)
+$ userlifecyle deprovision urn:collab:person:surf.nl:janis_joplin
+Continue with deprovisioning of "urn:collab:person:surf.nl:janis_joplin"? (y/n)
 # Will start deprovisioning after a positive answer to the confirmation.
 ```
 

--- a/tests/integration/DataFixtures/ORM/DatabaseTestFixtures.php
+++ b/tests/integration/DataFixtures/ORM/DatabaseTestFixtures.php
@@ -29,22 +29,22 @@ class DatabaseTestFixtures extends Fixture
     public function load(ObjectManager $manager)
     {
         $lastLoginJames = new LastLogin(
-            new CollabPersonId('urn:collab:org:surf.nl:james_watson'),
+            new CollabPersonId('urn:collab:person:surf.nl:james_watson'),
             new DateTime('2015-01-01')
         );
 
         $lastLoginJason = new LastLogin(
-            new CollabPersonId('urn:collab:org:surf.nl:jason_mraz'),
+            new CollabPersonId('urn:collab:person:surf.nl:jason_mraz'),
             new DateTime('2017-05-25')
         );
 
         $lastLoginJimi = new LastLogin(
-            new CollabPersonId('urn:collab:org:surf.nl:jimi_hendrix'),
+            new CollabPersonId('urn:collab:person:surf.nl:jimi_hendrix'),
             new DateTime('1970-09-28')
         );
 
         $lastLoginJohn = new LastLogin(
-            new CollabPersonId('urn:collab:org:surf.nl:john_doe'),
+            new CollabPersonId('urn:collab:person:surf.nl:john_doe'),
             new DateTime('2018-01-01')
         );
 

--- a/tests/integration/UserLifecycleBundle/Command/BatchDeprovisionCommandTest.php
+++ b/tests/integration/UserLifecycleBundle/Command/BatchDeprovisionCommandTest.php
@@ -115,7 +115,7 @@ class BatchDeprovisionCommandTest extends DatabaseTestCase
         // Ascertain we start of with 4 entries in the last login repository
         $this->assertCount(4, $this->repository->findAll());
 
-        $collabPersonId = 'urn:collab:org:surf.nl:jimi_hendrix';
+        $collabPersonId = 'urn:collab:person:surf.nl:jimi_hendrix';
         $this->handlerMyService->append(
             new Response(200, [], $this->getOkStatus('my_service_name', $collabPersonId))
         );
@@ -148,17 +148,17 @@ class BatchDeprovisionCommandTest extends DatabaseTestCase
         $this->assertCount(4, $this->repository->findAll());
 
         $this->handlerMyService->append(
-            new Response(200, [], $this->getOkStatus('my_service_name', 'user1')),
-            new Response(200, [], $this->getOkStatus('my_service_name', 'user2')),
-            new Response(200, [], $this->getOkStatus('my_service_name', 'user3')),
-            new Response(200, [], $this->getOkStatus('my_service_name', 'user4'))
+            new Response(200, [], $this->getOkStatus('my_service_name', 'urn:collab:person:user1')),
+            new Response(200, [], $this->getOkStatus('my_service_name', 'urn:collab:person:user2')),
+            new Response(200, [], $this->getOkStatus('my_service_name', 'urn:collab:person:user3')),
+            new Response(200, [], $this->getOkStatus('my_service_name', 'urn:collab:person:user4'))
         );
 
         $this->handlerMySecondService->append(
-            new Response(200, [], $this->getOkStatus('my_second_name', 'user1')),
-            new Response(200, [], $this->getOkStatus('my_second_name', 'user2')),
-            new Response(200, [], $this->getOkStatus('my_second_name', 'user3')),
-            new Response(200, [], $this->getOkStatus('my_second_name', 'user4'))
+            new Response(200, [], $this->getOkStatus('my_second_name', 'urn:collab:person:user1')),
+            new Response(200, [], $this->getOkStatus('my_second_name', 'urn:collab:person:user2')),
+            new Response(200, [], $this->getOkStatus('my_second_name', 'urn:collab:person:user3')),
+            new Response(200, [], $this->getOkStatus('my_second_name', 'urn:collab:person:user4'))
         );
 
         $command = $this->application->find('deprovision');
@@ -179,17 +179,17 @@ class BatchDeprovisionCommandTest extends DatabaseTestCase
         $this->assertCount(4, $this->repository->findAll());
 
         $this->handlerMyService->append(
-            new Response(200, [], $this->getOkStatus('my_service_name', 'user1')),
-            new Response(200, [], $this->getOkStatus('my_service_name', 'user2')),
-            new Response(200, [], $this->getOkStatus('my_service_name', 'user3')),
-            new Response(200, [], $this->getOkStatus('my_service_name', 'user4'))
+            new Response(200, [], $this->getOkStatus('my_service_name', 'urn:collab:person:user1')),
+            new Response(200, [], $this->getOkStatus('my_service_name', 'urn:collab:person:user2')),
+            new Response(200, [], $this->getOkStatus('my_service_name', 'urn:collab:person:user3')),
+            new Response(200, [], $this->getOkStatus('my_service_name', 'urn:collab:person:user4'))
         );
 
         $this->handlerMySecondService->append(
-            new Response(200, [], $this->getOkStatus('my_second_name', 'user1')),
-            new Response(200, [], $this->getOkStatus('my_second_name', 'user2')),
-            new Response(200, [], $this->getFailedStatus('my_second_name', 'user3')),
-            new Response(200, [], $this->getOkStatus('my_second_name', 'user4'))
+            new Response(200, [], $this->getOkStatus('my_second_name', 'urn:collab:person:user1')),
+            new Response(200, [], $this->getOkStatus('my_second_name', 'urn:collab:person:user2')),
+            new Response(200, [], $this->getFailedStatus('my_second_name', 'urn:collab:person:user3')),
+            new Response(200, [], $this->getOkStatus('my_second_name', 'urn:collab:person:user4'))
         );
 
         $command = $this->application->find('deprovision');
@@ -203,7 +203,7 @@ class BatchDeprovisionCommandTest extends DatabaseTestCase
         // After deprovisioning the user should have been removed from the last login table
         $this->assertCount(1, $this->repository->findAll());
         $this->assertStringContainsString(
-            '"Something went awfully wrong" for user "urn:collab:org:surf.nl:jason_mraz"',
+            '"Something went awfully wrong" for user "urn:collab:person:surf.nl:jason_mraz"',
             $output
         );
     }

--- a/tests/integration/UserLifecycleBundle/Command/DeprovisionCommandTest.php
+++ b/tests/integration/UserLifecycleBundle/Command/DeprovisionCommandTest.php
@@ -112,7 +112,7 @@ class DeprovisionCommandTest extends DatabaseTestCase
 
     public function test_execute()
     {
-        $collabPersonId = 'urn:collab:org:surf.nl:jimi_hendrix';
+        $collabPersonId = 'urn:collab:person:surf.nl:jimi_hendrix';
 
         $this->handlerMyService->append(
             new Response(200, [], $this->getOkStatus('my_service_name', $collabPersonId))
@@ -138,7 +138,7 @@ class DeprovisionCommandTest extends DatabaseTestCase
 
     public function test_execute_cancels_when_no_is_confirmed()
     {
-        $collabPersonId = 'urn:collab:org:surf.nl:jimi_hendrix';
+        $collabPersonId = 'urn:collab:person:surf.nl:jimi_hendrix';
 
         $this->handlerMyService->append(
             new Response(200, [], $this->getOkStatus('my_service_name', $collabPersonId))
@@ -164,7 +164,7 @@ class DeprovisionCommandTest extends DatabaseTestCase
 
     public function test_execute_dry_run()
     {
-        $collabPersonId = 'urn:collab:org:surf.nl:jimi_hendrix';
+        $collabPersonId = 'urn:collab:person:surf.nl:jimi_hendrix';
 
         $this->handlerMyService->append(
             new Response(200, [], $this->getOkStatus('my_service_name', $collabPersonId))
@@ -189,7 +189,7 @@ class DeprovisionCommandTest extends DatabaseTestCase
 
     public function test_execute_no_interaction()
     {
-        $collabPersonId = 'urn:collab:org:surf.nl:jimi_hendrix';
+        $collabPersonId = 'urn:collab:person:surf.nl:jimi_hendrix';
 
         $this->handlerMyService->append(
             new Response(200, [], $this->getOkStatus('my_service_name', $collabPersonId))
@@ -213,7 +213,7 @@ class DeprovisionCommandTest extends DatabaseTestCase
 
     public function test_execute_silently()
     {
-        $collabPersonId = 'urn:collab:org:surf.nl:jimi_hendrix';
+        $collabPersonId = 'urn:collab:person:surf.nl:jimi_hendrix';
 
         $this->handlerMyService->append(
             new Response(200, [], $this->getOkStatus('my_service_name', $collabPersonId))
@@ -237,7 +237,7 @@ class DeprovisionCommandTest extends DatabaseTestCase
     {
         $this->expectExceptionMessage("The --json option must be used in combination with --no-interaction (-n).");
         $this->expectException(RuntimeException::class);
-        $collabPersonId = 'urn:collab:org:surf.nl:jimi_hendrix';
+        $collabPersonId = 'urn:collab:person:surf.nl:jimi_hendrix';
 
         $command = $this->application->find('deprovision');
         $commandTester = new CommandTester($command);

--- a/tests/integration/UserLifecycleBundle/Command/InformationCommandTest.php
+++ b/tests/integration/UserLifecycleBundle/Command/InformationCommandTest.php
@@ -92,7 +92,7 @@ class LastLoginRepositoryTest extends DatabaseTestCase
 
     public function test_execute()
     {
-        $collabPersonId = 'urn:collab:org:surf.nl:jimi_hendrix';
+        $collabPersonId = 'urn:collab:person:surf.nl:jimi_hendrix';
 
         $this->handlerMyService->append(
             new Response(200, [], $this->getOkStatus('my_service_name', $collabPersonId))
@@ -114,7 +114,7 @@ class LastLoginRepositoryTest extends DatabaseTestCase
 
     public function test_execute_second_service_returned_failed_response()
     {
-        $collabPersonId = 'urn:collab:org:surf.nl:jimi_hendrix';
+        $collabPersonId = 'urn:collab:person:surf.nl:jimi_hendrix';
 
         $this->handlerMyService->append(
             new Response(200, [], $this->getOkStatus('my_service_name', $collabPersonId))
@@ -148,7 +148,7 @@ class LastLoginRepositoryTest extends DatabaseTestCase
 
     public function test_execute_silently()
     {
-        $collabPersonId = 'urn:collab:org:surf.nl:jimi_hendrix';
+        $collabPersonId = 'urn:collab:person:surf.nl:jimi_hendrix';
 
         $this->handlerMyService->append(
             new Response(200, [], $this->getOkStatus('my_service_name', $collabPersonId))

--- a/tests/integration/UserLifecycleBundle/Repository/LastLoginRepositoryTest.php
+++ b/tests/integration/UserLifecycleBundle/Repository/LastLoginRepositoryTest.php
@@ -57,7 +57,7 @@ class LastLoginRepositoryTest extends DatabaseTestCase
 
     public function test_delete()
     {
-        $userId ='urn:collab:org:surf.nl:jason_mraz';
+        $userId ='urn:collab:person:surf.nl:jason_mraz';
         $result = $this->repository->delete($userId);
 
         $this->assertNull($result, 'The delete message should return void.');
@@ -66,7 +66,7 @@ class LastLoginRepositoryTest extends DatabaseTestCase
 
     public function test_delete_non_exisiting()
     {
-        $userId ='urn:collab:org:surf.nl:joe_dirt';
+        $userId ='urn:collab:person:surf.nl:joe_dirt';
         $result = $this->repository->delete($userId);
 
         $this->assertNull($result, 'The delete message should return void.');

--- a/tests/unit/Application/Service/DeprovisionServiceTest.php
+++ b/tests/unit/Application/Service/DeprovisionServiceTest.php
@@ -90,7 +90,7 @@ class DeprovisionServiceTest extends TestCase
     public function test_deprovision()
     {
         // Setup the test using test doubles
-        $personId = 'jay-leno';
+        $personId = 'urn:collab:person:jay-leno';
         $collection = m::mock(InformationResponseCollectionInterface::class);
         $collection
             ->shouldReceive('jsonSerialize')
@@ -100,7 +100,7 @@ class DeprovisionServiceTest extends TestCase
             ->shouldReceive('deprovision')
             ->andReturnUsing(
                 function ($expectedCollabPersonId, $expectedDryRunState) use ($collection) {
-                    $this->assertEquals('jay-leno', $expectedCollabPersonId->getCollabPersonId());
+                    $this->assertEquals('urn:collab:person:jay-leno', $expectedCollabPersonId->getCollabPersonId());
                     $this->assertFalse($expectedDryRunState);
 
                     return $collection;
@@ -125,7 +125,7 @@ class DeprovisionServiceTest extends TestCase
     public function test_deprovision_dry_run()
     {
         // Setup the test using test doubles
-        $personId = 'jeff-beck';
+        $personId = 'urn:collab:person:jeff-beck';
         $collection = m::mock(InformationResponseCollectionInterface::class);
         $collection
             ->shouldReceive('jsonSerialize')
@@ -134,7 +134,7 @@ class DeprovisionServiceTest extends TestCase
         $this->apiCollection
             ->shouldReceive('deprovision')
             ->andReturnUsing(function ($expectedCollabPersonId, $expectedDryRunState) use ($collection) {
-                $this->assertEquals('jeff-beck', $expectedCollabPersonId->getCollabPersonId());
+                $this->assertEquals('urn:collab:person:jeff-beck', $expectedCollabPersonId->getCollabPersonId());
                 $this->assertTrue($expectedDryRunState);
                 return $collection;
             });
@@ -158,8 +158,8 @@ class DeprovisionServiceTest extends TestCase
     public function test_batch_deprovision()
     {
         $mockCollection = m::mock(LastLoginCollectionInterface::class);
-        $mockUser1 = $this->buildMockLastLoginEntry('jack-black');
-        $mockUser2 = $this->buildMockLastLoginEntry('jan-berry');
+        $mockUser1 = $this->buildMockLastLoginEntry('urn:collab:person:jack-black');
+        $mockUser2 = $this->buildMockLastLoginEntry('urn:collab:person:jan-berry');
 
         $this->lastLoginService
             ->shouldReceive('findUsersForDeprovision')
@@ -187,7 +187,10 @@ class DeprovisionServiceTest extends TestCase
             ->shouldReceive('deprovision')
             ->andReturnUsing(
                 function ($expectedCollabPersonId, $expectedDryRunState) use ($mockCollection, $collection) {
-                    $this->assertContains($expectedCollabPersonId->getCollabPersonId(), ['jack-black', 'jan-berry']);
+                    $this->assertContains(
+                        $expectedCollabPersonId->getCollabPersonId(),
+                        ['urn:collab:person:jack-black', 'urn:collab:person:jan-berry']
+                    );
                     $this->assertFalse($expectedDryRunState);
 
                     return $collection;
@@ -214,8 +217,8 @@ class DeprovisionServiceTest extends TestCase
     public function test_batch_deprovision_dry_run()
     {
         $mockCollection = m::mock(LastLoginCollectionInterface::class);
-        $mockUser1 = $this->buildMockLastLoginEntry('jack-black');
-        $mockUser2 = $this->buildMockLastLoginEntry('jan-berry');
+        $mockUser1 = $this->buildMockLastLoginEntry('urn:collab:person:jack-black');
+        $mockUser2 = $this->buildMockLastLoginEntry('urn:collab:person:jan-berry');
 
         $this->lastLoginService
             ->shouldReceive('findUsersForDeprovision')
@@ -243,7 +246,10 @@ class DeprovisionServiceTest extends TestCase
             ->shouldReceive('deprovision')
             ->andReturnUsing(
                 function ($expectedCollabPersonId, $expectedDryRunState) use ($mockCollection, $collection) {
-                    $this->assertContains($expectedCollabPersonId->getCollabPersonId(), ['jack-black', 'jan-berry']);
+                    $this->assertContains(
+                        $expectedCollabPersonId->getCollabPersonId(),
+                        ['urn:collab:person:jack-black', 'urn:collab:person:jan-berry']
+                    );
                     $this->assertTrue($expectedDryRunState);
 
                     return $collection;

--- a/tests/unit/Application/Service/InformationServiceTest.php
+++ b/tests/unit/Application/Service/InformationServiceTest.php
@@ -52,7 +52,7 @@ class InformationServiceTest extends TestCase
     public function test_read_information_for()
     {
         // Setup the test using test doubles
-        $personId = 'jay-leno';
+        $personId = 'urn:collab:person:jay-leno';
 
         $collection = m::mock(InformationResponseCollection::class);
         $collection


### PR DESCRIPTION
Due to stricter validation in a previous pull request (#43) some of the unit tests had to be changed so it complies to this validation.

https://www.pivotaltracker.com/story/show/158028385