### PR TITLE
Improve status reporting

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,8 @@
         "symfony/framework-bundle": "4.4.*",
         "symfony/http-kernel": "4.4.*",
         "symfony/monolog-bundle": "^3.1.0",
-        "symfony/security-bundle": "4.4.*"
+        "symfony/security-bundle": "4.4.*",
+        "symfony/stopwatch": "4.4.*"
     },
     "require-dev": {
         "doctrine/doctrine-fixtures-bundle": "^3.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0616945f3bfcfd34f6244872c1d9d6fe",
+    "content-hash": "94ecf156da470c7c9b0a0effc62895e5",
     "packages": [
         {
             "name": "composer/package-versions-deprecated",
@@ -5121,6 +5121,65 @@
                 }
             ],
             "time": "2021-11-04T16:48:04+00:00"
+        },
+        {
+            "name": "symfony/stopwatch",
+            "version": "v4.4.38",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/stopwatch.git",
+                "reference": "7f4f5a8122f7530d688cc9edf2f8c9261552fa2d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/stopwatch/zipball/7f4f5a8122f7530d688cc9edf2f8c9261552fa2d",
+                "reference": "7f4f5a8122f7530d688cc9edf2f8c9261552fa2d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1.3",
+                "symfony/service-contracts": "^1.0|^2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Stopwatch\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides a way to profile code",
+            "homepage": "https://symfony.com",
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-02-18T15:34:20+00:00"
         },
         {
             "name": "symfony/string",

--- a/src/OpenConext/UserLifecycle/Application/Command/RemoveFromLastLoginCommand.php
+++ b/src/OpenConext/UserLifecycle/Application/Command/RemoveFromLastLoginCommand.php
@@ -18,22 +18,27 @@
 
 namespace OpenConext\UserLifecycle\Application\Command;
 
+use OpenConext\UserLifecycle\Domain\Service\ProgressReporterInterface;
 use OpenConext\UserLifecycle\Domain\ValueObject\CollabPersonId;
 
 class RemoveFromLastLoginCommand implements CommandInterface
 {
     private $collabPersonId;
+    private $progressReporter;
 
-    public function __construct(CollabPersonId $personId)
+    public function __construct(CollabPersonId $personId, ProgressReporterInterface $progressReporter)
     {
         $this->collabPersonId = $personId;
+        $this->progressReporter = $progressReporter;
     }
 
-    /**
-     * @return CollabPersonId
-     */
-    public function getCollabPersonId()
+    public function getCollabPersonId(): CollabPersonId
     {
         return $this->collabPersonId;
+    }
+
+    public function getProgressReporter(): ProgressReporterInterface
+    {
+        return $this->progressReporter;
     }
 }

--- a/src/OpenConext/UserLifecycle/Application/Service/DeprovisionService.php
+++ b/src/OpenConext/UserLifecycle/Application/Service/DeprovisionService.php
@@ -24,6 +24,7 @@ use OpenConext\UserLifecycle\Domain\Client\BatchInformationResponseCollection;
 use OpenConext\UserLifecycle\Domain\Client\BatchInformationResponseCollectionInterface;
 use OpenConext\UserLifecycle\Domain\Client\DeprovisionClientCollectionInterface;
 use OpenConext\UserLifecycle\Domain\Client\InformationResponseCollectionInterface;
+use OpenConext\UserLifecycle\Domain\Service\ClientHealthCheckerInterface;
 use OpenConext\UserLifecycle\Domain\Service\DeprovisionServiceInterface;
 use OpenConext\UserLifecycle\Domain\Service\LastLoginServiceInterface;
 use OpenConext\UserLifecycle\Domain\Service\ProgressReporterInterface;
@@ -36,7 +37,7 @@ use Webmozart\Assert\Assert;
 /**
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  */
-class DeprovisionService implements DeprovisionServiceInterface
+class DeprovisionService implements DeprovisionServiceInterface, ClientHealthCheckerInterface
 {
     /**
      * @var DeprovisionClientCollectionInterface
@@ -96,7 +97,6 @@ class DeprovisionService implements DeprovisionServiceInterface
         $collabPersonId = $this->buildCollabPersonId($personId);
 
         $this->logger->debug('Delegate deprovisioning to the registered services.');
-
         $information = $this->deprovisionClientCollection->deprovision($collabPersonId, $dryRun);
 
         $this->logger->info(
@@ -126,7 +126,6 @@ class DeprovisionService implements DeprovisionServiceInterface
         $users = $this->lastLoginService->findUsersForDeprovision();
         $this->logger->debug('Perform sanity checks on the response from the last login service.');
         $this->sanityCheckService->check($users);
-
         $batchInformationCollection = new BatchInformationResponseCollection();
 
         foreach ($users->getData() as $currentIndex => $lastLogin) {
@@ -165,5 +164,10 @@ class DeprovisionService implements DeprovisionServiceInterface
         Assert::stringNotEmpty($personId, 'Please pass a non empty collabPersonId');
 
         return new CollabPersonId($personId);
+    }
+
+    public function healthCheck(): void
+    {
+        $this->deprovisionClientCollection->healthCheck();
     }
 }

--- a/src/OpenConext/UserLifecycle/Application/Service/DeprovisionService.php
+++ b/src/OpenConext/UserLifecycle/Application/Service/DeprovisionService.php
@@ -124,7 +124,6 @@ class DeprovisionService implements DeprovisionServiceInterface
     {
         $this->logger->debug('Retrieve the users that are marked for deprovisioning.');
         $users = $this->lastLoginService->findUsersForDeprovision();
-
         $this->logger->debug('Perform sanity checks on the response from the last login service.');
         $this->sanityCheckService->check($users);
 

--- a/src/OpenConext/UserLifecycle/Application/Service/InformationService.php
+++ b/src/OpenConext/UserLifecycle/Application/Service/InformationService.php
@@ -21,15 +21,16 @@ namespace OpenConext\UserLifecycle\Application\Service;
 use InvalidArgumentException;
 use OpenConext\UserLifecycle\Domain\Client\DeprovisionClientCollectionInterface;
 use OpenConext\UserLifecycle\Domain\Client\InformationResponseCollectionInterface;
+use OpenConext\UserLifecycle\Domain\Service\ClientHealthCheckerInterface;
 use OpenConext\UserLifecycle\Domain\Service\InformationServiceInterface;
 use OpenConext\UserLifecycle\Domain\ValueObject\CollabPersonId;
 use Psr\Log\LoggerInterface;
 use Webmozart\Assert\Assert;
 
-class InformationService implements InformationServiceInterface
+class InformationService implements InformationServiceInterface, ClientHealthCheckerInterface
 {
     /**
-     * @var DeprovisionClientCollectionInterface
+     * @var DeprovisionClientCollectionInterface&ClientHealthCheckerInterface
      */
     private $deprovisionClientCollection;
 
@@ -58,7 +59,6 @@ class InformationService implements InformationServiceInterface
         Assert::stringNotEmpty($personId, 'Please pass a non empty collabPersonId');
 
         $collabPersonId = new CollabPersonId($personId);
-
         $this->logger->debug('Retrieve the information from the APIs for the user.');
         $information = $this->deprovisionClientCollection->information($collabPersonId);
 
@@ -68,5 +68,9 @@ class InformationService implements InformationServiceInterface
         );
 
         return $information;
+    }
+    public function healthCheck(): void
+    {
+        $this->deprovisionClientCollection->healthCheck();
     }
 }

--- a/src/OpenConext/UserLifecycle/Application/Service/ProgressReporterInterface.php
+++ b/src/OpenConext/UserLifecycle/Application/Service/ProgressReporterInterface.php
@@ -28,10 +28,5 @@ interface ProgressReporterInterface extends BaseProgressReporterInterface
      */
     public function setConsoleOutput(OutputInterface $output);
 
-    /**
-     * @param string $message
-     * @param int $total
-     * @param int $current
-     */
-    public function progress($message, $total, $current);
+    public function progress(string $message, int $total, int $current): void;
 }

--- a/src/OpenConext/UserLifecycle/Application/Service/SummaryService.php
+++ b/src/OpenConext/UserLifecycle/Application/Service/SummaryService.php
@@ -21,6 +21,7 @@ namespace OpenConext\UserLifecycle\Application\Service;
 use OpenConext\UserLifecycle\Domain\Client\BatchInformationResponseCollectionInterface;
 use OpenConext\UserLifecycle\Domain\Client\InformationResponseCollectionInterface;
 use OpenConext\UserLifecycle\Domain\Service\SummaryServiceInterface;
+use const PHP_EOL;
 
 class SummaryService implements SummaryServiceInterface
 {
@@ -33,6 +34,13 @@ class SummaryService implements SummaryServiceInterface
     const USER_INFORMATION_JSON_HEADING = 'Full output of the information command:';
 
     const BATCH_DEPROVISION_ERROR_FORMAT = '%d deprovision calls to services failed. See error messages below:';
+
+    private $progressReporter;
+
+    public function __construct(ProgressReporterInterface $progressReporter)
+    {
+        $this->progressReporter = $progressReporter;
+    }
 
     public function summarizeInformationResponse(InformationResponseCollectionInterface $collection)
     {
@@ -74,6 +82,9 @@ class SummaryService implements SummaryServiceInterface
 
     public function summarizeBatchResponse(BatchInformationResponseCollectionInterface $collection)
     {
+
+        $this->progressReporter->printDeprovisionStatistics() . PHP_EOL;
+
         $errorMessageList = '';
 
         $errorMessages = $collection->getErrorMessages();
@@ -84,7 +95,7 @@ class SummaryService implements SummaryServiceInterface
             }
         }
 
-        return $errorMessageList.PHP_EOL.self::USER_DEPROVISION_JSON_HEADING.PHP_EOL;
+        return PHP_EOL.$errorMessageList.PHP_EOL.self::USER_DEPROVISION_JSON_HEADING.PHP_EOL;
     }
 
     private function pluralizeService($count)

--- a/src/OpenConext/UserLifecycle/Domain/Client/DeprovisionClientInterface.php
+++ b/src/OpenConext/UserLifecycle/Domain/Client/DeprovisionClientInterface.php
@@ -25,27 +25,20 @@ interface DeprovisionClientInterface
 {
     /**
      * Can be used to deprovision a user from the OpenConext platform.
-     *
-     * @param CollabPersonId $user
-     * @param bool $dryRun
-     * @return PromiseInterface
      */
-    public function deprovision(CollabPersonId $user, $dryRun = false);
+    public function deprovision(CollabPersonId $user, bool $dryRun = false): PromiseInterface;
 
     /**
      * Can be used to gather information about a user on the OpenConext platform.
      *
      * Returns a Json encoded string containing the user information provided by the different deprovision API's.
-     *
-     * @param CollabPersonId|null $user
-     * @return PromiseInterface
      */
-    public function information(CollabPersonId $user);
+    public function information(CollabPersonId $user): PromiseInterface;
 
     /**
      * Returns the name of the client, as configured in the parameters.yml
-     *
-     * @return string
      */
-    public function getName();
+    public function getName(): string;
+
+    public function health(): void;
 }

--- a/src/OpenConext/UserLifecycle/Domain/Client/InformationResponseCollection.php
+++ b/src/OpenConext/UserLifecycle/Domain/Client/InformationResponseCollection.php
@@ -18,6 +18,8 @@
 
 namespace OpenConext\UserLifecycle\Domain\Client;
 
+use function array_key_exists;
+
 class InformationResponseCollection implements InformationResponseCollectionInterface
 {
     /**
@@ -25,7 +27,7 @@ class InformationResponseCollection implements InformationResponseCollectionInte
      */
     private $data = [];
 
-    public function addInformationResponse(InformationResponseInterface $informationResponse)
+    public function addInformationResponse(InformationResponseInterface $informationResponse): void
     {
         $this->data[] = $informationResponse;
     }
@@ -33,7 +35,7 @@ class InformationResponseCollection implements InformationResponseCollectionInte
     /**
      * @return InformationResponseInterface[]
      */
-    public function getInformationResponses()
+    public function getInformationResponses(): array
     {
         return $this->data;
     }
@@ -41,7 +43,7 @@ class InformationResponseCollection implements InformationResponseCollectionInte
     /**
      * @return string[]
      */
-    public function getErrorMessages()
+    public function getErrorMessages(): array
     {
         $messages = [];
         foreach ($this->data as $entry) {
@@ -52,16 +54,28 @@ class InformationResponseCollection implements InformationResponseCollectionInte
         return $messages;
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return $this->data;
     }
 
-    /**
-     * @return int
-     */
-    public function count()
+    public function count(): int
     {
         return count($this->data);
+    }
+
+    public function successesPerClient(): array
+    {
+        $report = [];
+        foreach ($this->data as $entry) {
+            if (is_null($entry->getErrorMessage()) || !$entry->getErrorMessage()->hasErrorMessage()) {
+                $clientName = (string) $entry->getName();
+                if (!array_key_exists($clientName, $report)) {
+                    $report[$clientName] = 0;
+                }
+                $report[$clientName]++;
+            }
+        }
+        return $report;
     }
 }

--- a/src/OpenConext/UserLifecycle/Domain/Client/InformationResponseCollectionInterface.php
+++ b/src/OpenConext/UserLifecycle/Domain/Client/InformationResponseCollectionInterface.php
@@ -26,25 +26,24 @@ interface InformationResponseCollectionInterface extends JsonSerializable, Count
     /**
      * @param InformationResponseInterface $informationResponse
      */
-    public function addInformationResponse(InformationResponseInterface $informationResponse);
+    public function addInformationResponse(InformationResponseInterface $informationResponse): void;
 
     /**
      * @return InformationResponseInterface[]
      */
-    public function getInformationResponses();
+    public function getInformationResponses(): array;
 
     /**
      * @return string[]
      */
-    public function getErrorMessages();
+    public function getErrorMessages(): array;
+
+    public function jsonSerialize(): array;
+
+    public function count(): int;
 
     /**
-     * @return array
+     * @return int[]
      */
-    public function jsonSerialize();
-
-    /**
-     * @return int
-     */
-    public function count();
+    public function successesPerClient(): array;
 }

--- a/src/OpenConext/UserLifecycle/Domain/Exception/DeprovisionClientUnavailableException.php
+++ b/src/OpenConext/UserLifecycle/Domain/Exception/DeprovisionClientUnavailableException.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * Copyright 2022 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenConext\UserLifecycle\Domain\Exception;
+
+use RuntimeException;
+use Throwable;
+
+class DeprovisionClientUnavailableException extends RuntimeException
+{
+    public function __construct(string $clientName, $code = 0, Throwable $previous = null)
+    {
+        $message = sprintf("Connection failed to backend '%s'", $clientName);
+        parent::__construct($message, $code, $previous);
+    }
+}

--- a/src/OpenConext/UserLifecycle/Domain/Repository/LastLoginRepositoryInterface.php
+++ b/src/OpenConext/UserLifecycle/Domain/Repository/LastLoginRepositoryInterface.php
@@ -30,8 +30,6 @@ interface LastLoginRepositoryInterface
 
     /**
      * Delete an entry from the last login table identified by collabPersonId
-     *
-     * @param $collabPersonId
      */
-    public function delete($collabPersonId);
+    public function delete(string $collabPersonId);
 }

--- a/src/OpenConext/UserLifecycle/Domain/Service/ClientHealthCheckerInterface.php
+++ b/src/OpenConext/UserLifecycle/Domain/Service/ClientHealthCheckerInterface.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Copyright 2018 SURFnet B.V.
+ * Copyright 2022 SURFnet B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,31 +16,14 @@
  * limitations under the License.
  */
 
-namespace OpenConext\UserLifecycle\Domain\Client;
+namespace OpenConext\UserLifecycle\Domain\Service;
 
 use OpenConext\UserLifecycle\Domain\Exception\DeprovisionClientUnavailableException;
-use OpenConext\UserLifecycle\Domain\ValueObject\CollabPersonId;
 
-interface DeprovisionClientCollectionInterface
+interface ClientHealthCheckerInterface
 {
-    public function addClient(DeprovisionClientInterface $client);
-
-    /**
-     * @param CollabPersonId $user
-     * @param bool $dryRun
-     *
-     * @return InformationResponseCollectionInterface
-     */
-    public function deprovision(CollabPersonId $user, $dryRun = false);
-
-    /**
-     * @param CollabPersonId $user
-     * @return InformationResponseCollectionInterface
-     */
-    public function information(CollabPersonId $user);
-
     /**
      * @throws DeprovisionClientUnavailableException
      */
-    public function healthCheck();
+    public function healthCheck(): void;
 }

--- a/src/OpenConext/UserLifecycle/Domain/Service/DeprovisionServiceInterface.php
+++ b/src/OpenConext/UserLifecycle/Domain/Service/DeprovisionServiceInterface.php
@@ -28,7 +28,7 @@ interface DeprovisionServiceInterface
      * @param bool $dryRun
      * @return InformationResponseCollectionInterface
      */
-    public function deprovision($personId, $dryRun = false);
+    public function deprovision(ProgressReporterInterface $progressReporter, $personId, $dryRun = false);
 
     /**
      * Finds the users marked for deprovisioning, and deprovisions them.

--- a/src/OpenConext/UserLifecycle/Domain/Service/ProgressReporterInterface.php
+++ b/src/OpenConext/UserLifecycle/Domain/Service/ProgressReporterInterface.php
@@ -20,12 +20,13 @@ namespace OpenConext\UserLifecycle\Domain\Service;
 
 interface ProgressReporterInterface
 {
+    public function progress(string $message, int $total, int $current): void;
+    
+    public function startStopwatch(): void;
+    public function stopStopwatch(): void;
 
+    public function reportDeprovisionedFromService(array $statistics): void;
+    public function reportRemovedFromLastLogin(): void;
 
-    /**
-     * @param string $message
-     * @param int $total
-     * @param int $current
-     */
-    public function progress($message, $total, $current);
+    public function printDeprovisionStatistics();
 }

--- a/src/OpenConext/UserLifecycle/Domain/Service/StopwatchInterface.php
+++ b/src/OpenConext/UserLifecycle/Domain/Service/StopwatchInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * Copyright 2022 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenConext\UserLifecycle\Domain\Service;
+
+interface StopwatchInterface
+{
+    public function start(): void;
+    public function stop(): void;
+    public function elapsedTime(): float;
+}

--- a/src/OpenConext/UserLifecycle/Domain/ValueObject/DeprovisionStatistics.php
+++ b/src/OpenConext/UserLifecycle/Domain/ValueObject/DeprovisionStatistics.php
@@ -1,0 +1,60 @@
+<?php
+
+/**
+ * Copyright 2022 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenConext\UserLifecycle\Domain\ValueObject;
+
+use JsonSerializable;
+
+class DeprovisionStatistics implements JsonSerializable
+{
+    private $runtime = 0;
+    private $deprovisionedPerClient = [];
+    private $lastLoginRemovals = 0;
+
+    public function addDeprovisionedPerClient(array $deprovisionStatistics): void
+    {
+        foreach ($deprovisionStatistics as $serviceName => $numberOfRemovals) {
+            if (!array_key_exists($serviceName, $this->deprovisionedPerClient)) {
+                $this->deprovisionedPerClient[$serviceName] = 0;
+            }
+            $this->deprovisionedPerClient[$serviceName] += $numberOfRemovals;
+        }
+    }
+
+    public function addLastLoginRemoval(): void
+    {
+        $this->lastLoginRemovals++;
+    }
+
+    /**
+     * Runtime should be in seconds
+     */
+    public function setRuntime(int $runtime): void
+    {
+        $this->runtime = $runtime;
+    }
+
+    public function jsonSerialize(): array
+    {
+        return [
+            'runtime' => $this->runtime,
+            'deprovisioned-per-client' => $this->deprovisionedPerClient,
+            'last-login-removals' => $this->lastLoginRemovals
+        ];
+    }
+}

--- a/src/OpenConext/UserLifecycle/Infrastructure/UserLifecycleBundle/Client/DeprovisionClient.php
+++ b/src/OpenConext/UserLifecycle/Infrastructure/UserLifecycleBundle/Client/DeprovisionClient.php
@@ -110,7 +110,6 @@ class DeprovisionClient implements DeprovisionClientInterface
         $resource = $this->buildResourcePath($path, $parameters);
 
         $promise = $this->httpClient->requestAsync('GET', $resource, ['exceptions' => false]);
-
         return $promise->then(
             function (Response $response) use ($resource) {
                 try {

--- a/src/OpenConext/UserLifecycle/Infrastructure/UserLifecycleBundle/Client/DeprovisionClientCollection.php
+++ b/src/OpenConext/UserLifecycle/Infrastructure/UserLifecycleBundle/Client/DeprovisionClientCollection.php
@@ -24,6 +24,7 @@ use OpenConext\UserLifecycle\Domain\Client\DeprovisionClientCollectionInterface;
 use OpenConext\UserLifecycle\Domain\Client\DeprovisionClientInterface;
 use OpenConext\UserLifecycle\Domain\Client\InformationResponseCollection;
 use OpenConext\UserLifecycle\Domain\Client\InformationResponseCollectionInterface;
+use OpenConext\UserLifecycle\Domain\Exception\DeprovisionClientUnavailableException;
 use OpenConext\UserLifecycle\Domain\ValueObject\CollabPersonId;
 
 class DeprovisionClientCollection implements DeprovisionClientCollectionInterface
@@ -80,8 +81,15 @@ class DeprovisionClientCollection implements DeprovisionClientCollectionInterfac
 
         foreach ($informationResponses as $informationResponse) {
             $collection->addInformationResponse($informationResponse);
-        };
+        }
 
         return $collection;
+    }
+
+    public function healthCheck()
+    {
+        foreach ($this->clients as $client) {
+            $client->health();
+        }
     }
 }

--- a/src/OpenConext/UserLifecycle/Infrastructure/UserLifecycleBundle/Command/DeprovisionCommand.php
+++ b/src/OpenConext/UserLifecycle/Infrastructure/UserLifecycleBundle/Command/DeprovisionCommand.php
@@ -115,13 +115,13 @@ class DeprovisionCommand extends Command
         $outputOnlyJson = $input->getOption('json');
         $prettyJson = $input->getOption('pretty');
         $noInteraction = $input->getOption('no-interaction');
-
+        $this->progressReporter->startStopwatch();
         if ($outputOnlyJson && $noInteraction === false) {
             throw new RuntimeException('The --json option must be used in combination with --no-interaction (-n).');
         }
 
         if (is_null($userIdInput)) {
-            return $this->executeBatch(
+            $exitCode = $this->executeBatch(
                 $input,
                 $output,
                 $userIdInput,
@@ -131,7 +131,7 @@ class DeprovisionCommand extends Command
                 $prettyJson
             );
         } else {
-            return $this->executeSingleUser(
+            $exitCode = $this->executeSingleUser(
                 $input,
                 $output,
                 $userIdInput,
@@ -141,6 +141,7 @@ class DeprovisionCommand extends Command
                 $prettyJson
             );
         }
+        return $exitCode;
     }
 
     private function executeBatch(
@@ -224,7 +225,7 @@ class DeprovisionCommand extends Command
         try {
             $this->logger->debug('Health check the remote services.');
             $this->service->healthCheck();
-            $information = $this->service->deprovision($userIdInput, $dryRun);
+            $information = $this->service->deprovision($this->progressReporter, $userIdInput, $dryRun);
 
             if (!$outputOnlyJson) {
                 $output->write($this->summaryService->summarizeDeprovisionResponse($information), true);

--- a/src/OpenConext/UserLifecycle/Infrastructure/UserLifecycleBundle/Command/DeprovisionCommand.php
+++ b/src/OpenConext/UserLifecycle/Infrastructure/UserLifecycleBundle/Command/DeprovisionCommand.php
@@ -21,6 +21,7 @@ namespace OpenConext\UserLifecycle\Infrastructure\UserLifecycleBundle\Command;
 use Exception;
 use JsonSerializable;
 use OpenConext\UserLifecycle\Application\Service\ProgressReporterInterface;
+use OpenConext\UserLifecycle\Domain\Service\ClientHealthCheckerInterface;
 use OpenConext\UserLifecycle\Domain\Service\DeprovisionServiceInterface;
 use OpenConext\UserLifecycle\Domain\Service\SummaryServiceInterface;
 use OpenConext\UserLifecycle\Infrastructure\UserLifecycleBundle\Exception\RuntimeException;
@@ -40,7 +41,7 @@ class DeprovisionCommand extends Command
     private $logger;
 
     /**
-     * @var DeprovisionServiceInterface
+     * @var DeprovisionServiceInterface&ClientHealthCheckerInterface
      */
     private $service;
 
@@ -174,6 +175,8 @@ class DeprovisionCommand extends Command
         }
 
         try {
+            $this->logger->debug('Health check the remote services.');
+            $this->service->healthCheck();
             $information = $this->service->batchDeprovision($this->progressReporter, $dryRun);
 
             if (!$outputOnlyJson) {
@@ -219,6 +222,8 @@ class DeprovisionCommand extends Command
             )
         );
         try {
+            $this->logger->debug('Health check the remote services.');
+            $this->service->healthCheck();
             $information = $this->service->deprovision($userIdInput, $dryRun);
 
             if (!$outputOnlyJson) {

--- a/src/OpenConext/UserLifecycle/Infrastructure/UserLifecycleBundle/Command/InformationCommand.php
+++ b/src/OpenConext/UserLifecycle/Infrastructure/UserLifecycleBundle/Command/InformationCommand.php
@@ -20,6 +20,7 @@ namespace OpenConext\UserLifecycle\Infrastructure\UserLifecycleBundle\Command;
 
 use Exception;
 use OpenConext\UserLifecycle\Application\Service\InformationService;
+use OpenConext\UserLifecycle\Domain\Service\ClientHealthCheckerInterface;
 use OpenConext\UserLifecycle\Domain\Service\InformationServiceInterface;
 use OpenConext\UserLifecycle\Domain\Service\SummaryServiceInterface;
 use Psr\Log\LoggerInterface;
@@ -37,7 +38,7 @@ class InformationCommand extends Command
     private $logger;
 
     /**
-     * @var InformationService
+     * @var InformationService&ClientHealthCheckerInterface
      */
     private $service;
 
@@ -103,6 +104,8 @@ class InformationCommand extends Command
         $this->logger->info(sprintf('Received an information request for user: "%s"', $userIdInput));
 
         try {
+            $this->logger->debug('Health check the remote services.');
+            $this->service->healthCheck();
             $information = $this->service->readInformationFor($userIdInput);
 
             if (!$outputOnlyJson) {

--- a/src/OpenConext/UserLifecycle/Infrastructure/UserLifecycleBundle/Exception/DatabaseConnectionException.php
+++ b/src/OpenConext/UserLifecycle/Infrastructure/UserLifecycleBundle/Exception/DatabaseConnectionException.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * Copyright 2022 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenConext\UserLifecycle\Infrastructure\UserLifecycleBundle\Exception;
+
+use JetBrains\PhpStorm\Internal\LanguageLevelTypeAware;
+use RuntimeException as CoreRuntimeException;
+
+class DatabaseConnectionException extends CoreRuntimeException
+{
+    public function __construct(
+        $message = "No connection possible to the database",
+        $code = 0,
+        Throwable $previous = null
+    ) {
+        parent::__construct($message, $code, $previous);
+    }
+}

--- a/src/OpenConext/UserLifecycle/Infrastructure/UserLifecycleBundle/Repository/LastLoginRepository.php
+++ b/src/OpenConext/UserLifecycle/Infrastructure/UserLifecycleBundle/Repository/LastLoginRepository.php
@@ -21,6 +21,7 @@ namespace OpenConext\UserLifecycle\Infrastructure\UserLifecycleBundle\Repository
 use DateTime;
 use Doctrine\DBAL\Exception\ConnectionException;
 use Doctrine\ORM\EntityRepository;
+use Doctrine\ORM\Query\QueryException;
 use OpenConext\UserLifecycle\Domain\Collection\LastLoginCollection;
 use OpenConext\UserLifecycle\Domain\Repository\LastLoginRepositoryInterface;
 use OpenConext\UserLifecycle\Infrastructure\UserLifecycleBundle\Exception\DatabaseConnectionException;
@@ -56,7 +57,7 @@ class LastLoginRepository extends EntityRepository implements LastLoginRepositor
      *
      * @param string $collabPersonId
      */
-    public function delete($collabPersonId)
+    public function delete(string $collabPersonId)
     {
         Assert::stringNotEmpty($collabPersonId);
 

--- a/src/OpenConext/UserLifecycle/Infrastructure/UserLifecycleBundle/Resources/config/services.yml
+++ b/src/OpenConext/UserLifecycle/Infrastructure/UserLifecycleBundle/Resources/config/services.yml
@@ -65,6 +65,11 @@ services:
 
     OpenConext\UserLifecycle\Domain\Client\InformationResponseFactoryInterface: '@OpenConext\UserLifecycle\Application\Client\InformationResponseFactory'
 
+    OpenConext\UserLifecycle\Domain\Service\StopwatchInterface:
+        class: OpenConext\UserLifecycle\Infrastructure\UserLifecycleBundle\Service\Stopwatch
+        arguments:
+            $stopwatch: '@Symfony\Component\Stopwatch\Stopwatch'
+
     open_conext.user_lifecycle.deprovision_client.guzzle_stack:
         public: false
         class: 'GuzzleHttp\HandlerStack'

--- a/src/OpenConext/UserLifecycle/Infrastructure/UserLifecycleBundle/Service/Stopwatch.php
+++ b/src/OpenConext/UserLifecycle/Infrastructure/UserLifecycleBundle/Service/Stopwatch.php
@@ -1,0 +1,74 @@
+<?php
+
+/**
+ * Copyright 2022 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenConext\UserLifecycle\Infrastructure\UserLifecycleBundle\Service;
+
+use DateTime;
+use Doctrine\DBAL\Exception\ConnectionException;
+use Doctrine\ORM\EntityRepository;
+use OpenConext\UserLifecycle\Domain\Collection\LastLoginCollection;
+use OpenConext\UserLifecycle\Domain\Repository\LastLoginRepositoryInterface;
+use OpenConext\UserLifecycle\Domain\Service\StopwatchInterface;
+use OpenConext\UserLifecycle\Infrastructure\UserLifecycleBundle\Exception\DatabaseConnectionException;
+use OpenConext\UserLifecycle\Infrastructure\UserLifecycleBundle\Exception\RuntimeException;
+use Symfony\Component\Stopwatch\Stopwatch as SymfonyStopwatch;
+use Webmozart\Assert\Assert;
+
+class Stopwatch implements StopwatchInterface
+{
+    private const TIMER = 'timer';
+    /**
+     * @var SymfonyStopwatch
+     */
+    private $stopwatch;
+
+    private $isStarted = false;
+    private $isStopped = false;
+
+    public function __construct(SymfonyStopwatch $stopwatch)
+    {
+        $this->stopwatch = $stopwatch;
+    }
+
+    public function start(): void
+    {
+        $this->isStarted = true;
+        $this->stopwatch->start(self::TIMER);
+    }
+
+    public function stop(): void
+    {
+        if (!$this->isStarted) {
+            throw new RuntimeException("Unable to stop a stopwatch that was not started");
+        }
+        $this->isStopped = true;
+        $this->stopwatch->stop(self::TIMER);
+    }
+
+    public function elapsedTime(): float
+    {
+        if (!$this->isStarted) {
+            throw new RuntimeException("Unable to get the elapsed time of a stopwatch that was not started");
+        }
+        if (!$this->isStopped) {
+            throw new RuntimeException("First stop the stopwatch before getting elapsed time");
+        }
+
+        return $this->stopwatch->getEvent(self::TIMER)->getDuration();
+    }
+}

--- a/symfony.lock
+++ b/symfony.lock
@@ -181,6 +181,9 @@
     "symfony/security-http": {
         "version": "v4.4.37"
     },
+    "symfony/stopwatch": {
+        "version": "v4.4.38"
+    },
     "theseer/fdomdocument": {
         "version": "1.6.7"
     },

--- a/tests/integration/UserLifecycleBundle/Command/BatchDeprovisionCommandTest.php
+++ b/tests/integration/UserLifecycleBundle/Command/BatchDeprovisionCommandTest.php
@@ -117,10 +117,12 @@ class BatchDeprovisionCommandTest extends DatabaseTestCase
 
         $collabPersonId = 'urn:collab:person:surf.nl:jimi_hendrix';
         $this->handlerMyService->append(
+            new Response(200, [], '{"status":"UP"}'),
             new Response(200, [], $this->getOkStatus('my_service_name', $collabPersonId))
         );
 
         $this->handlerMySecondService->append(
+            new Response(200, [], '{"status":"UP"}'),
             new Response(200, [], $this->getOkStatus('my_second_name', $collabPersonId))
         );
 
@@ -148,6 +150,7 @@ class BatchDeprovisionCommandTest extends DatabaseTestCase
         $this->assertCount(4, $this->repository->findAll());
 
         $this->handlerMyService->append(
+            new Response(200, [], '{"status":"UP"}'),
             new Response(200, [], $this->getOkStatus('my_service_name', 'urn:collab:person:user1')),
             new Response(200, [], $this->getOkStatus('my_service_name', 'urn:collab:person:user2')),
             new Response(200, [], $this->getOkStatus('my_service_name', 'urn:collab:person:user3')),
@@ -155,6 +158,7 @@ class BatchDeprovisionCommandTest extends DatabaseTestCase
         );
 
         $this->handlerMySecondService->append(
+            new Response(200, [], '{"status":"UP"}'),
             new Response(200, [], $this->getOkStatus('my_second_name', 'urn:collab:person:user1')),
             new Response(200, [], $this->getOkStatus('my_second_name', 'urn:collab:person:user2')),
             new Response(200, [], $this->getOkStatus('my_second_name', 'urn:collab:person:user3')),
@@ -179,6 +183,7 @@ class BatchDeprovisionCommandTest extends DatabaseTestCase
         $this->assertCount(4, $this->repository->findAll());
 
         $this->handlerMyService->append(
+            new Response(200, [], '{"status":"UP"}'),
             new Response(200, [], $this->getOkStatus('my_service_name', 'urn:collab:person:user1')),
             new Response(200, [], $this->getOkStatus('my_service_name', 'urn:collab:person:user2')),
             new Response(200, [], $this->getOkStatus('my_service_name', 'urn:collab:person:user3')),
@@ -186,6 +191,7 @@ class BatchDeprovisionCommandTest extends DatabaseTestCase
         );
 
         $this->handlerMySecondService->append(
+            new Response(200, [], '{"status":"UP"}'),
             new Response(200, [], $this->getOkStatus('my_second_name', 'urn:collab:person:user1')),
             new Response(200, [], $this->getOkStatus('my_second_name', 'urn:collab:person:user2')),
             new Response(200, [], $this->getFailedStatus('my_second_name', 'urn:collab:person:user3')),

--- a/tests/integration/UserLifecycleBundle/Command/BatchDeprovisionCommandTest.php
+++ b/tests/integration/UserLifecycleBundle/Command/BatchDeprovisionCommandTest.php
@@ -28,11 +28,13 @@ use OpenConext\UserLifecycle\Application\Service\SummaryService;
 use OpenConext\UserLifecycle\Domain\Entity\LastLogin;
 use OpenConext\UserLifecycle\Infrastructure\UserLifecycleBundle\Command\DeprovisionCommand;
 use OpenConext\UserLifecycle\Infrastructure\UserLifecycleBundle\Repository\LastLoginRepository;
+use OpenConext\UserLifecycle\Infrastructure\UserLifecycleBundle\Service\Stopwatch;
 use OpenConext\UserLifecycle\Tests\Integration\DatabaseTestCase;
 use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\Stopwatch\Stopwatch as FrameworkStopwatch;
 
 class BatchDeprovisionCommandTest extends DatabaseTestCase
 {
@@ -87,9 +89,11 @@ class BatchDeprovisionCommandTest extends DatabaseTestCase
         // Create the application and add the information command
         $this->application = new Application();
 
+
         $deprovisionService = self::$container->get(DeprovisionService::class);
 
-        $summaryService = new SummaryService();
+        $progressReporter = new ProgressReporter(new Stopwatch(new FrameworkStopwatch()));
+        $summaryService = new SummaryService($progressReporter);
 
         // Set the time on the LastLoginRepository
         $this->repository = self::$container
@@ -100,7 +104,6 @@ class BatchDeprovisionCommandTest extends DatabaseTestCase
         $logger = m::mock(LoggerInterface::class);
         $logger->shouldIgnoreMissing();
 
-        $progressReporter = new ProgressReporter();
 
         $this->application->add(
             new DeprovisionCommand($deprovisionService, $summaryService, $progressReporter, $logger)
@@ -151,18 +154,18 @@ class BatchDeprovisionCommandTest extends DatabaseTestCase
 
         $this->handlerMyService->append(
             new Response(200, [], '{"status":"UP"}'),
-            new Response(200, [], $this->getOkStatus('my_service_name', 'urn:collab:person:user1')),
-            new Response(200, [], $this->getOkStatus('my_service_name', 'urn:collab:person:user2')),
-            new Response(200, [], $this->getOkStatus('my_service_name', 'urn:collab:person:user3')),
-            new Response(200, [], $this->getOkStatus('my_service_name', 'urn:collab:person:user4'))
+            new Response(200, [], $this->getOkStatus('my_service_name', 'urn:collab:person:surf.nl:james_watson')),
+            new Response(200, [], $this->getOkStatus('my_service_name', 'urn:collab:person:surf.nl:john_doe')),
+            new Response(200, [], $this->getOkStatus('my_service_name', 'urn:collab:person:surf.nl:jimi_hendrix')),
+            new Response(200, [], $this->getOkStatus('my_service_name', 'urn:collab:person:surf.nl:jason_mraz'))
         );
 
         $this->handlerMySecondService->append(
             new Response(200, [], '{"status":"UP"}'),
-            new Response(200, [], $this->getOkStatus('my_second_name', 'urn:collab:person:user1')),
-            new Response(200, [], $this->getOkStatus('my_second_name', 'urn:collab:person:user2')),
-            new Response(200, [], $this->getOkStatus('my_second_name', 'urn:collab:person:user3')),
-            new Response(200, [], $this->getOkStatus('my_second_name', 'urn:collab:person:user4'))
+            new Response(200, [], $this->getOkStatus('my_second_name', 'urn:collab:person:surf.nl:james_watson')),
+            new Response(200, [], $this->getOkStatus('my_second_name', 'urn:collab:person:surf.nl:jimi_hendrix')),
+            new Response(200, [], $this->getOkStatus('my_second_name', 'urn:collab:person:surf.nl:jason_mraz')),
+            new Response(200, [], $this->getOkStatus('my_second_name', 'urn:collab:person:surf.nl:john_doe'))
         );
 
         $command = $this->application->find('deprovision');
@@ -171,9 +174,20 @@ class BatchDeprovisionCommandTest extends DatabaseTestCase
         $commandTester->setInputs(['yes']);
         $commandTester->execute([]);
 
+        $output = $commandTester->getDisplay();
+
+        // The deprovision reporting should show correct data
+        $this->assertStringContainsString('"runtime":0', $output);
+        $this->assertStringContainsString('"last-login-removals":4', $output);
+        $this->assertStringContainsString(
+            '"deprovisioned-per-client":{"my_service_name":4,"my_second_name":4}',
+            $output
+        );
+
         // After deprovisioning the user should have been removed from the last login table
         $this->assertCount(0, $this->repository->findAll());
     }
+
     public function test_execute_multiple_users_one_failure()
     {
         // Set the repository time in the future, ensuring deprovisioning of all users in the last login table

--- a/tests/integration/UserLifecycleBundle/Command/DeprovisionCommandTest.php
+++ b/tests/integration/UserLifecycleBundle/Command/DeprovisionCommandTest.php
@@ -115,10 +115,12 @@ class DeprovisionCommandTest extends DatabaseTestCase
         $collabPersonId = 'urn:collab:person:surf.nl:jimi_hendrix';
 
         $this->handlerMyService->append(
+            new Response(200, [], '{"status":"UP"}'),
             new Response(200, [], $this->getOkStatus('my_service_name', $collabPersonId))
         );
 
         $this->handlerMySecondService->append(
+            new Response(200, [], '{"status":"UP"}'),
             new Response(200, [], $this->getOkStatus('my_second_name', $collabPersonId))
         );
 
@@ -141,10 +143,12 @@ class DeprovisionCommandTest extends DatabaseTestCase
         $collabPersonId = 'urn:collab:person:surf.nl:jimi_hendrix';
 
         $this->handlerMyService->append(
+            new Response(200, [], '{"status":"UP"}'),
             new Response(200, [], $this->getOkStatus('my_service_name', $collabPersonId))
         );
 
         $this->handlerMySecondService->append(
+            new Response(200, [], '{"status":"UP"}'),
             new Response(200, [], $this->getOkStatus('my_second_name', $collabPersonId))
         );
 
@@ -167,10 +171,12 @@ class DeprovisionCommandTest extends DatabaseTestCase
         $collabPersonId = 'urn:collab:person:surf.nl:jimi_hendrix';
 
         $this->handlerMyService->append(
+            new Response(200, [], '{"status":"UP"}'),
             new Response(200, [], $this->getOkStatus('my_service_name', $collabPersonId))
         );
 
         $this->handlerMySecondService->append(
+            new Response(200, [], '{"status":"UP"}'),
             new Response(200, [], $this->getOkStatus('my_second_name', $collabPersonId))
         );
 
@@ -192,10 +198,12 @@ class DeprovisionCommandTest extends DatabaseTestCase
         $collabPersonId = 'urn:collab:person:surf.nl:jimi_hendrix';
 
         $this->handlerMyService->append(
+            new Response(200, [], '{"status":"UP"}'),
             new Response(200, [], $this->getOkStatus('my_service_name', $collabPersonId))
         );
 
         $this->handlerMySecondService->append(
+            new Response(200, [], '{"status":"UP"}'),
             new Response(200, [], $this->getOkStatus('my_second_name', $collabPersonId))
         );
 
@@ -216,10 +224,12 @@ class DeprovisionCommandTest extends DatabaseTestCase
         $collabPersonId = 'urn:collab:person:surf.nl:jimi_hendrix';
 
         $this->handlerMyService->append(
+            new Response(200, [], '{"status":"UP"}'),
             new Response(200, [], $this->getOkStatus('my_service_name', $collabPersonId))
         );
 
         $this->handlerMySecondService->append(
+            new Response(200, [], '{"status":"UP"}'),
             new Response(200, [], $this->getOkStatus('my_second_name', $collabPersonId))
         );
 

--- a/tests/integration/UserLifecycleBundle/Command/InformationCommandTest.php
+++ b/tests/integration/UserLifecycleBundle/Command/InformationCommandTest.php
@@ -22,13 +22,16 @@ use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\Psr7\Response;
 use Mockery as m;
 use OpenConext\UserLifecycle\Application\Service\InformationService;
+use OpenConext\UserLifecycle\Application\Service\ProgressReporter;
 use OpenConext\UserLifecycle\Application\Service\SummaryService;
 use OpenConext\UserLifecycle\Infrastructure\UserLifecycleBundle\Command\InformationCommand;
+use OpenConext\UserLifecycle\Infrastructure\UserLifecycleBundle\Service\Stopwatch;
 use OpenConext\UserLifecycle\Tests\Integration\DatabaseTestCase;
 use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\Stopwatch\Stopwatch as FrameworkStopwatch;
 
 class LastLoginRepositoryTest extends DatabaseTestCase
 {
@@ -79,7 +82,9 @@ class LastLoginRepositoryTest extends DatabaseTestCase
         $this->application = new Application();
 
         $lastLoginService = self::$kernel->getContainer()->get(InformationService::class);
-        $summaryService = new SummaryService();
+
+        $progressReporter = new ProgressReporter(new Stopwatch(new FrameworkStopwatch()));
+        $summaryService = new SummaryService($progressReporter);
 
         $logger = m::mock(LoggerInterface::class);
         $logger->shouldIgnoreMissing();

--- a/tests/integration/UserLifecycleBundle/Command/InformationCommandTest.php
+++ b/tests/integration/UserLifecycleBundle/Command/InformationCommandTest.php
@@ -95,10 +95,12 @@ class LastLoginRepositoryTest extends DatabaseTestCase
         $collabPersonId = 'urn:collab:person:surf.nl:jimi_hendrix';
 
         $this->handlerMyService->append(
+            new Response(200, [], '{"status":"UP"}'),
             new Response(200, [], $this->getOkStatus('my_service_name', $collabPersonId))
         );
 
         $this->handlerMySecondService->append(
+            new Response(200, [], '{"status":"UP"}'),
             new Response(200, [], $this->getOkStatus('my_second_name', $collabPersonId))
         );
 
@@ -117,11 +119,13 @@ class LastLoginRepositoryTest extends DatabaseTestCase
         $collabPersonId = 'urn:collab:person:surf.nl:jimi_hendrix';
 
         $this->handlerMyService->append(
+            new Response(200, [], '{"status":"UP"}'),
             new Response(200, [], $this->getOkStatus('my_service_name', $collabPersonId))
         );
 
         $errorMessage = 'Internal server error';
         $this->handlerMySecondService->append(
+            new Response(200, [], '{"status":"UP"}'),
             new Response(200, [], $this->getFailedStatus('my_second_name', $errorMessage))
         );
         $command = $this->application->find('information');
@@ -151,11 +155,13 @@ class LastLoginRepositoryTest extends DatabaseTestCase
         $collabPersonId = 'urn:collab:person:surf.nl:jimi_hendrix';
 
         $this->handlerMyService->append(
+            new Response(200, [], '{"status":"UP"}'),
             new Response(200, [], $this->getOkStatus('my_service_name', $collabPersonId))
         );
 
         $errorMessage = 'Internal server error';
         $this->handlerMySecondService->append(
+            new Response(200, [], '{"status":"UP"}'),
             new Response(200, [], $this->getFailedStatus('my_second_name', $errorMessage))
         );
         $command = $this->application->find('information');

--- a/tests/unit/Application/CommandHandler/RemoveFromLastLoginCommandHandlerTest.php
+++ b/tests/unit/Application/CommandHandler/RemoveFromLastLoginCommandHandlerTest.php
@@ -27,6 +27,7 @@ use OpenConext\UserLifecycle\Application\Query\InactiveUsersQuery;
 use OpenConext\UserLifecycle\Application\QueryHandler\InactiveUsersQueryHandler;
 use OpenConext\UserLifecycle\Domain\Collection\LastLoginCollectionInterface;
 use OpenConext\UserLifecycle\Domain\Repository\LastLoginRepositoryInterface;
+use OpenConext\UserLifecycle\Domain\Service\ProgressReporterInterface;
 use OpenConext\UserLifecycle\Domain\ValueObject\CollabPersonId;
 use OpenConext\UserLifecycle\Domain\ValueObject\InactivityPeriod;
 use PHPUnit\Framework\TestCase;
@@ -49,6 +50,7 @@ class RemoveFromLastLoginCommandHandlerTest extends TestCase
     {
         $this->repository = m::mock(LastLoginRepositoryInterface::class);
         $this->commandHandler = new RemoveFromLastLoginCommandHandler($this->repository);
+        $this->progressReporter = m::mock(ProgressReporterInterface::class);
     }
 
     public function test_handle()
@@ -57,7 +59,7 @@ class RemoveFromLastLoginCommandHandlerTest extends TestCase
         $collabPersonId
             ->shouldReceive('__toString')
             ->andReturn('urn:collab:org:surf.nl:james_carter');
-        $query = new RemoveFromLastLoginCommand($collabPersonId);
+        $query = new RemoveFromLastLoginCommand($collabPersonId, $this->progressReporter);
 
         $this->repository
             ->shouldReceive('delete')

--- a/tests/unit/Application/Service/DeprovisionServiceTest.php
+++ b/tests/unit/Application/Service/DeprovisionServiceTest.php
@@ -27,6 +27,7 @@ use OpenConext\UserLifecycle\Application\Service\DeprovisionService;
 use OpenConext\UserLifecycle\Domain\Client\InformationResponseCollectionInterface;
 use OpenConext\UserLifecycle\Domain\Collection\LastLoginCollectionInterface;
 use OpenConext\UserLifecycle\Domain\Entity\LastLogin;
+use OpenConext\UserLifecycle\Domain\Service\DeprovisionClientHealthCheckerInterface;
 use OpenConext\UserLifecycle\Domain\Service\LastLoginServiceInterface;
 use OpenConext\UserLifecycle\Domain\Service\ProgressReporterInterface;
 use OpenConext\UserLifecycle\Domain\Service\RemovalCheckServiceInterface;
@@ -71,7 +72,12 @@ class DeprovisionServiceTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->apiCollection = m::mock(DeprovisionClientCollection::class);
+        $this->apiCollection = m::mock(
+            DeprovisionClientCollection::class,
+            DeprovisionClientHealthCheckerInterface::class
+        );
+        $this->apiCollection
+            ->shouldReceive('healthCheck');
         $this->sanityChecker = m::mock(SanityCheckServiceInterface::class);
         $this->lastLoginService = m::mock(LastLoginServiceInterface::class);
         $this->removalCheckService = m::mock(RemovalCheckServiceInterface::class);

--- a/tests/unit/Application/Service/InformationServiceTest.php
+++ b/tests/unit/Application/Service/InformationServiceTest.php
@@ -64,7 +64,7 @@ class InformationServiceTest extends TestCase
         $collection = m::mock(InformationResponseCollection::class);
         $collection
             ->shouldReceive('jsonSerialize')
-            ->andReturn('{"only": "test"}');
+            ->andReturn(["only" => "test"]);
 
         $this->apiCollection
             ->shouldReceive('information')

--- a/tests/unit/Application/Service/InformationServiceTest.php
+++ b/tests/unit/Application/Service/InformationServiceTest.php
@@ -25,6 +25,8 @@ use Mockery\Mock;
 use OpenConext\UserLifecycle\Application\Service\InformationService;
 use OpenConext\UserLifecycle\Domain\Client\DeprovisionClientCollectionInterface;
 use OpenConext\UserLifecycle\Domain\Client\InformationResponseCollection;
+use OpenConext\UserLifecycle\Domain\Service\DeprovisionClientHealthCheckerInterface;
+use OpenConext\UserLifecycle\Infrastructure\UserLifecycleBundle\Client\DeprovisionClientCollection;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 
@@ -44,7 +46,12 @@ class InformationServiceTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->apiCollection = m::mock(DeprovisionClientCollectionInterface::class);
+        $this->apiCollection = m::mock(
+            DeprovisionClientCollection::class,
+            DeprovisionClientHealthCheckerInterface::class
+        );
+        $this->apiCollection
+            ->shouldReceive('healthCheck');
         $logger = m::mock(LoggerInterface::class)->shouldIgnoreMissing();
         $this->service = new InformationService($this->apiCollection, $logger);
     }

--- a/tests/unit/Application/Service/ProgressReporterTest.php
+++ b/tests/unit/Application/Service/ProgressReporterTest.php
@@ -21,6 +21,7 @@ namespace OpenConext\UserLifecycle\Tests\Unit\Application\Service;
 use Mockery as m;
 use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use OpenConext\UserLifecycle\Application\Service\ProgressReporter;
+use OpenConext\UserLifecycle\Domain\Service\StopwatchInterface;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -30,7 +31,7 @@ class ProgressReporterTest extends TestCase
 
     public function test_reporter_does_nothing_without_console_output_object()
     {
-        $reporter = new ProgressReporter();
+        $reporter = new ProgressReporter(m::mock(StopwatchInterface::class));
         $this->assertNull(
             $reporter->progress('test', 1, 100)
         );
@@ -51,7 +52,7 @@ class ProgressReporterTest extends TestCase
             ->shouldReceive('writeln')
             ->with('[100% of 4 users]    test');
 
-        $reporter = new ProgressReporter();
+        $reporter = new ProgressReporter(m::mock(StopwatchInterface::class));
         $reporter->setConsoleOutput($output);
 
         $reporter->progress('test', 4, 0);

--- a/tests/unit/Infrastructure/UserLifecycleBundle/Service/StopwatchTest.php
+++ b/tests/unit/Infrastructure/UserLifecycleBundle/Service/StopwatchTest.php
@@ -1,0 +1,72 @@
+<?php
+
+/**
+ * Copyright 2022 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenConext\UserLifecycle\Tests\Unit\Infrastructure\UserLifecycleBundle\Service;
+
+use OpenConext\UserLifecycle\Infrastructure\UserLifecycleBundle\Exception\RuntimeException;
+use OpenConext\UserLifecycle\Infrastructure\UserLifecycleBundle\Service\Stopwatch;
+use PHPUnit\Framework\TestCase;
+use function is_float;
+use function sleep;
+
+class StopwatchTest extends TestCase
+{
+    private $stopwatch;
+
+    protected function setUp(): void
+    {
+        $this->stopwatch =  new Stopwatch(new \Symfony\Component\Stopwatch\Stopwatch());
+    }
+    public function test_it_can_start_and_stop()
+    {
+        $this->stopwatch->start();
+        $this->stopwatch->stop();
+        $this->assertTrue(is_float($this->stopwatch->elapsedTime()));
+    }
+
+    public function test_elapsed_time_returns_expected_value()
+    {
+        $this->stopwatch->start();
+        sleep(1); // Sleep 1000 miliseconds
+        $this->stopwatch->stop();
+        $elapsedTime = $this->stopwatch->elapsedTime();
+        $this->assertEquals(1000, $elapsedTime);
+    }
+
+    public function test_can_not_get_elapsed_time_before_started()
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage("Unable to get the elapsed time of a stopwatch that was not started");
+        $this->stopwatch->elapsedTime();
+    }
+
+    public function test_can_not_get_elapsed_time_before_stopped()
+    {
+        $this->stopwatch->start();
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage("First stop the stopwatch before getting elapsed time");
+        $this->stopwatch->elapsedTime();
+    }
+
+    public function test_can_not_stop_before_started()
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage("Unable to stop a stopwatch that was not started");
+        $this->stopwatch->stop();
+    }
+}


### PR DESCRIPTION
This is an effort to improve error/info reporting for the user lifecycle application.

1. When an error occurs that should halt execution, a more user friendly error message is displayed. This is implemneted in the first two commits.
2. Statistical information about the run was added in the 3 other commits. 

See: https://www.pivotaltracker.com/story/show/176168526