### PR TITLE
Create a last_login test data seeder

### DIFF
--- a/bin/seed_test_users.sh
+++ b/bin/seed_test_users.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+numberExpression='^[0-9]+$'
+databasePath=var/user-lifecycle.sqlite
+
+if ! [[ $1 =~ $numberExpression ]] ; then
+   echo "Usage: The first argument must be a number. Indicating the number of identities you'd like to seed to the last_login table" >&2
+   exit 1
+fi
+
+if ! [[ $2 =~ $numberExpression ]] ; then
+   echo "Usage: The second argument must be a number. Indicating the number of days since last login for all users" >&2
+   exit 1
+fi
+
+if ! [ -x "$(command -v sqlite3)" ]; then
+    echo "SQLite is not installed"
+    exit 1
+fi
+if ! [ -x "$(command -v rig)" ]; then
+    echo "Rig is not installed. Rig is used to create a random username."
+    exit 1
+fi
+
+if ! [ -f "${databasePath}" ]; then
+    echo "The SQLite database was not found at '${databasePath}'"
+    exit 1
+fi
+
+echo "Adding ${1} users to the last_login test table.."
+for ((i = 1 ; i <= $1 ; i++)) do
+    randomUserName=`rig | head -n 1 |  tr ' ' _ | tr A-Z a-z`
+    timeLastLogin=`date --rfc-3339=date -d "-${2} days"`
+
+    query="insert into last_login (userid, lastseen) values ('urn:collab:person:user:example.com:${randomUserName}', '${timeLastLogin}');"
+    sqlite3 ${databasePath} "${query}"
+done

--- a/bin/seed_test_users.sh
+++ b/bin/seed_test_users.sh
@@ -17,10 +17,6 @@ if ! [ -x "$(command -v sqlite3)" ]; then
     echo "SQLite is not installed"
     exit 1
 fi
-if ! [ -x "$(command -v rig)" ]; then
-    echo "Rig is not installed. Rig is used to create a random username."
-    exit 1
-fi
 
 if ! [ -f "${databasePath}" ]; then
     echo "The SQLite database was not found at '${databasePath}'"
@@ -29,7 +25,7 @@ fi
 
 echo "Adding ${1} users to the last_login test table.."
 for ((i = 1 ; i <= $1 ; i++)) do
-    randomUserName=`rig | head -n 1 |  tr ' ' _ | tr A-Z a-z`
+    randomUserName=`cat /dev/urandom | tr -dc '[:alpha:]' | fold -w ${1:-20} | head -n 1`
     timeLastLogin=`date --rfc-3339=date -d "-${2} days"`
 
     query="insert into last_login (userid, lastseen) values ('urn:collab:person:user:example.com:${randomUserName}', '${timeLastLogin}');"


### PR DESCRIPTION
This seeder can create a given amount of last_login entries. A date offset must be specified to control the date of the users last login time.

This script is usefull when you want to simulate larger batch deprovision actions. But note that the actual users probably do not exist on the platform.