### PR TITLE
Bring monolog config in sync with OC projects

### DIFF
--- a/config/packages/monolog.yaml
+++ b/config/packages/monolog.yaml
@@ -1,14 +1,12 @@
 monolog:
     handlers:
         main:
+            type: fingers_crossed
+            action_level: ERROR
+            passthru_level: NOTICE
+            handler: syslog
+            channels: ['!event', '!doctrine']
+        syslog:
             type: syslog
-            ident: userlifecycle
-            facility: user
-            channels: ['!event', '!doctrine']
-            level: INFO
+            ident: userlifecycle_stats
             formatter: OpenConext\UserLifecycle\Infrastructure\UserLifecycleBundle\Monolog\Formatter\JsonFormatter
-        console:
-            type: console
-            verbosity_levels:
-                VERBOSITY_NORMAL: CRITICAL
-            channels: ['!event', '!doctrine']


### PR DESCRIPTION
1. Removed irrelevant console config section. It did not change error output significantly.
2. The main/syslog setup has been brought up to date with the way other OpenConext loggers are configured.

Verified that: the syslog entries are JSON encoded, and that the console error output remains the same.