### PR TITLE
Change exit code and log deprovision statistics

### DIFF
--- a/src/OpenConext/UserLifecycle/Application/Service/ProgressReporter.php
+++ b/src/OpenConext/UserLifecycle/Application/Service/ProgressReporter.php
@@ -19,10 +19,9 @@
 namespace OpenConext\UserLifecycle\Application\Service;
 
 use OpenConext\UserLifecycle\Domain\Service\StopwatchInterface;
-use OpenConext\UserLifecycle\Domain\ValueObject\CollabPersonId;
 use OpenConext\UserLifecycle\Domain\ValueObject\DeprovisionStatistics;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\Console\Output\OutputInterface;
-use function json_encode;
 
 class ProgressReporter implements ProgressReporterInterface
 {
@@ -41,10 +40,16 @@ class ProgressReporter implements ProgressReporterInterface
      */
     private $deprovisionStatistics;
 
-    public function __construct(StopwatchInterface $stopwatch)
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    public function __construct(StopwatchInterface $stopwatch, LoggerInterface $logger)
     {
         $this->stopwatch = $stopwatch;
         $this->deprovisionStatistics = new DeprovisionStatistics();
+        $this->logger = $logger;
     }
 
     public function setConsoleOutput(OutputInterface $output)
@@ -104,6 +109,8 @@ class ProgressReporter implements ProgressReporterInterface
     {
         $this->deprovisionStatistics->setRuntime((int) $this->stopwatch->elapsedTime() / 1000);
 
-        $this->output->writeln(json_encode($this->deprovisionStatistics->jsonSerialize()));
+        $stats = json_encode($this->deprovisionStatistics->jsonSerialize());
+        $this->logger->info($stats);
+        $this->output->writeln($stats);
     }
 }

--- a/src/OpenConext/UserLifecycle/Infrastructure/UserLifecycleBundle/Command/DeprovisionCommand.php
+++ b/src/OpenConext/UserLifecycle/Infrastructure/UserLifecycleBundle/Command/DeprovisionCommand.php
@@ -153,6 +153,7 @@ class DeprovisionCommand extends Command
         $outputOnlyJson,
         $prettyJson
     ): int {
+        $exitCode = 0;
         if (!$noInteraction) {
             $helper = $this->getHelper('question');
             $question = new ConfirmationQuestion(
@@ -180,6 +181,10 @@ class DeprovisionCommand extends Command
             $this->service->healthCheck();
             $information = $this->service->batchDeprovision($this->progressReporter, $dryRun);
 
+            // If deprovisioning yielded one or more errors, change the exit code to 1
+            if (count($information->getErrorMessages()) > 0) {
+                $exitCode = 1;
+            }
             if (!$outputOnlyJson) {
                 $output->writeln('');
                 $output->write($this->summaryService->summarizeBatchResponse($information), true);
@@ -191,7 +196,7 @@ class DeprovisionCommand extends Command
             $this->logger->error($e->getMessage());
             return 1;
         }
-        return 0;
+        return $exitCode;
     }
 
     private function executeSingleUser(

--- a/tests/integration/UserLifecycleBundle/Command/BatchDeprovisionCommandTest.php
+++ b/tests/integration/UserLifecycleBundle/Command/BatchDeprovisionCommandTest.php
@@ -92,7 +92,10 @@ class BatchDeprovisionCommandTest extends DatabaseTestCase
 
         $deprovisionService = self::$container->get(DeprovisionService::class);
 
-        $progressReporter = new ProgressReporter(new Stopwatch(new FrameworkStopwatch()));
+        $progressReporter = new ProgressReporter(
+            new Stopwatch(new FrameworkStopwatch()),
+            m::mock(LoggerInterface::class)->shouldIgnoreMissing()
+        );
         $summaryService = new SummaryService($progressReporter);
 
         // Set the time on the LastLoginRepository
@@ -139,7 +142,7 @@ class BatchDeprovisionCommandTest extends DatabaseTestCase
 
         $this->assertStringContainsString($collabPersonId, $output);
         $this->assertStringContainsString('OK', $output);
-
+        $this->assertEquals(0, $commandTester->getStatusCode());
         // After deprovisioning the user should have been removed from the last login table
         $this->assertCount(3, $this->repository->findAll());
     }
@@ -183,7 +186,7 @@ class BatchDeprovisionCommandTest extends DatabaseTestCase
             '"deprovisioned-per-client":{"my_service_name":4,"my_second_name":4}',
             $output
         );
-
+        $this->assertEquals(0, $commandTester->getStatusCode());
         // After deprovisioning the user should have been removed from the last login table
         $this->assertCount(0, $this->repository->findAll());
     }
@@ -219,7 +222,7 @@ class BatchDeprovisionCommandTest extends DatabaseTestCase
         $commandTester->execute([]);
 
         $output = $commandTester->getDisplay();
-
+        $this->assertEquals(1, $commandTester->getStatusCode());
         // After deprovisioning the user should have been removed from the last login table
         $this->assertCount(1, $this->repository->findAll());
         $this->assertStringContainsString(

--- a/tests/integration/UserLifecycleBundle/Command/DeprovisionCommandTest.php
+++ b/tests/integration/UserLifecycleBundle/Command/DeprovisionCommandTest.php
@@ -97,7 +97,10 @@ class DeprovisionCommandTest extends DatabaseTestCase
         $this->repository->setNow(new DateTime('2018-01-01'));
 
         $deprovisionService = self::$container->get(DeprovisionService::class);
-        $progressReporter = new ProgressReporter(new Stopwatch(new FrameworkStopwatch()));
+        $progressReporter = new ProgressReporter(
+            new Stopwatch(new FrameworkStopwatch()),
+            m::mock(LoggerInterface::class)
+        );
         $summaryService = new SummaryService($progressReporter);
 
         $logger = m::mock(LoggerInterface::class);

--- a/tests/integration/UserLifecycleBundle/Command/InformationCommandTest.php
+++ b/tests/integration/UserLifecycleBundle/Command/InformationCommandTest.php
@@ -21,6 +21,7 @@ namespace OpenConext\UserLifecycle\Tests\Integration\UserLifecycleBundle\Command
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\Psr7\Response;
 use Mockery as m;
+use Monolog\Logger;
 use OpenConext\UserLifecycle\Application\Service\InformationService;
 use OpenConext\UserLifecycle\Application\Service\ProgressReporter;
 use OpenConext\UserLifecycle\Application\Service\SummaryService;
@@ -83,7 +84,10 @@ class LastLoginRepositoryTest extends DatabaseTestCase
 
         $lastLoginService = self::$kernel->getContainer()->get(InformationService::class);
 
-        $progressReporter = new ProgressReporter(new Stopwatch(new FrameworkStopwatch()));
+        $progressReporter = new ProgressReporter(
+            new Stopwatch(new FrameworkStopwatch()),
+            m::mock(LoggerInterface::class)
+        );
         $summaryService = new SummaryService($progressReporter);
 
         $logger = m::mock(LoggerInterface::class);

--- a/tests/unit/Application/Service/ProgressReporterTest.php
+++ b/tests/unit/Application/Service/ProgressReporterTest.php
@@ -23,6 +23,7 @@ use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use OpenConext\UserLifecycle\Application\Service\ProgressReporter;
 use OpenConext\UserLifecycle\Domain\Service\StopwatchInterface;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class ProgressReporterTest extends TestCase
@@ -31,7 +32,7 @@ class ProgressReporterTest extends TestCase
 
     public function test_reporter_does_nothing_without_console_output_object()
     {
-        $reporter = new ProgressReporter(m::mock(StopwatchInterface::class));
+        $reporter = new ProgressReporter(m::mock(StopwatchInterface::class), m::mock(LoggerInterface::class));
         $this->assertNull(
             $reporter->progress('test', 1, 100)
         );
@@ -52,7 +53,7 @@ class ProgressReporterTest extends TestCase
             ->shouldReceive('writeln')
             ->with('[100% of 4 users]    test');
 
-        $reporter = new ProgressReporter(m::mock(StopwatchInterface::class));
+        $reporter = new ProgressReporter(m::mock(StopwatchInterface::class), m::mock(LoggerInterface::class));
         $reporter->setConsoleOutput($output);
 
         $reporter->progress('test', 4, 0);


### PR DESCRIPTION
Two features in one PR. 

1. The exit code changed to 1 when one of the deprovision actions failed. Ensuring the output will be mailed by the cronmailer to the sysadmin.
2. The deprovision stats are now logged to syslog, before they only ended up in the console output.