### PR TITLE
Log using `stream` handler by default

### DIFF
--- a/config/packages/dev/monolog.yaml
+++ b/config/packages/dev/monolog.yaml
@@ -1,6 +1,5 @@
 monolog:
   handlers:
     main:
-      type: stream
       path: '%kernel.logs_dir%/%kernel.environment%.log'
-      level: debug
+      level: DEBUG

--- a/config/packages/monolog.yaml
+++ b/config/packages/monolog.yaml
@@ -1,9 +1,8 @@
 monolog:
     handlers:
         main:
-            type: fingers_crossed
-            action_level: ERROR
-            passthru_level: NOTICE
+            type: stream
+            level: INFO # Logs all messages at info level and higher severities
             handler: syslog
             channels: ['!event', '!doctrine']
         syslog:

--- a/config/packages/test/monolog.yaml
+++ b/config/packages/test/monolog.yaml
@@ -1,6 +1,5 @@
 monolog:
   handlers:
     main:
-      type: stream
       path: '%kernel.logs_dir%/%kernel.environment%.log'
-      level: debug
+      level: DEBUG


### PR DESCRIPTION
Previously we used the fingers_crossed strategy by default. That resulted in the stats not being logged. And that was a hard log requirement.