### PR TITLE
Set environments to prod

### DIFF
--- a/bin/makeRelease.sh
+++ b/bin/makeRelease.sh
@@ -67,6 +67,8 @@ rm -rf ${PROJECT_DIR}/.github &&
 rm -rf ${PROJECT_DIR}/ci &&
 rm -rf ${PROJECT_DIR}/tests &&
 rm -rf ${PROJECT_DIR}/docs &&
+# Remove the cache folders, we do not include a cache in the release tarbal.
+rm -rf ${PROJECT_DIR}/var/cache/prod/* &&
 rm -f ${PROJECT_DIR}/.gitignore &&
 rm -f ${PROJECT_DIR}/bin/makeRelease.sh &&
 rm -f ${PROJECT_DIR}/*.xml &&

--- a/bin/makeRelease.sh
+++ b/bin/makeRelease.sh
@@ -2,6 +2,8 @@
 
 PREVIOUS_SF_ENV=${SYMFONY_ENV}
 export SYMFONY_ENV="prod"
+export APP_ENV="prod"
+export APP_DEBUG=false
 
 RELEASE_DIR=${HOME}/Releases
 GITHUB_USER=OpenConext


### PR DESCRIPTION
Tweak the release script:

1. Run the release in prod mode, with debug disabled
2. The dev cache folder is now no longer created in the Tarbal. A prod cache is added instead.