### PR TITLE
Creating an error message with multiple messages causes fatal error

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -88,7 +88,10 @@
         "platform": {
             "php": "7.2.5"
         },
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "symfony/flex": true
+        }
     },
     "extra": {
         "symfony": {

--- a/src/OpenConext/UserLifecycle/Domain/ValueObject/Client/ErrorMessage.php
+++ b/src/OpenConext/UserLifecycle/Domain/ValueObject/Client/ErrorMessage.php
@@ -18,6 +18,10 @@
 
 namespace OpenConext\UserLifecycle\Domain\ValueObject\Client;
 
+use InvalidArgumentException;
+use function is_array;
+use function is_string;
+
 class ErrorMessage
 {
     /**
@@ -30,6 +34,14 @@ class ErrorMessage
      */
     public function __construct($errorMessage = null)
     {
+        // Setting multiple error messages is supported, but only if all array entries are of type string
+        if (is_array($errorMessage)) {
+            foreach ($errorMessage as $message) {
+                if (!is_string($message)) {
+                    throw new InvalidArgumentException('All of the error messages must be of type string');
+                }
+            }
+        }
         $this->errorMessage = $errorMessage;
     }
 
@@ -45,6 +57,10 @@ class ErrorMessage
 
     public function __toString()
     {
-        return $this->getErrorMessage();
+        $message = $this->getErrorMessage();
+        if (is_array($message)) {
+            $message = implode(', ', $message);
+        }
+        return (string) $message;
     }
 }


### PR DESCRIPTION
When an erroneous situation is encountered, a client can report back with a `FAILED` status. The error message included on that status message can explain what sort of error was encountered. During testing of the StepUp deprovisioning, we encountered an issue where passing multiple error messages wrapped in an array was not supported. 

This support is now added. Whether or not this is very useful is open for debate. 

When multiple (string) messages are present. And when they are presented to the log or output buffer, they are concatenated into a singular string. Seperated by a `, `.

https://www.pivotaltracker.com/story/show/182988799
