### PR TITLE
Fix TypeError

### DIFF
--- a/ci/qa/phpstan-baseline.neon
+++ b/ci/qa/phpstan-baseline.neon
@@ -286,11 +286,6 @@ parameters:
 			path: ../../src/OpenConext/UserLifecycle/Infrastructure/UserLifecycleBundle/Command/InformationCommand.php
 
 		-
-			message: "#^Parameter \\#1 \\$collection of method OpenConext\\\\UserLifecycle\\\\Domain\\\\Service\\\\SummaryServiceInterface\\:\\:summarizeInformationResponse\\(\\) expects OpenConext\\\\UserLifecycle\\\\Domain\\\\Client\\\\InformationResponseCollectionInterface, OpenConext\\\\UserLifecycle\\\\Domain\\\\Client\\\\InformationResponseInterface given\\.$#"
-			count: 1
-			path: ../../src/OpenConext/UserLifecycle/Infrastructure/UserLifecycleBundle/Command/InformationCommand.php
-
-		-
 			message: "#^Parameter \\#1 \\$messages of method Symfony\\\\Component\\\\Console\\\\Output\\\\OutputInterface\\:\\:write\\(\\) expects iterable\\<string\\>\\|string, string\\|false given\\.$#"
 			count: 1
 			path: ../../src/OpenConext/UserLifecycle/Infrastructure/UserLifecycleBundle/Command/InformationCommand.php

--- a/src/OpenConext/UserLifecycle/Application/QueryHandler/FindUserInformationQueryHandler.php
+++ b/src/OpenConext/UserLifecycle/Application/QueryHandler/FindUserInformationQueryHandler.php
@@ -21,6 +21,7 @@ declare(strict_types = 1);
 namespace OpenConext\UserLifecycle\Application\QueryHandler;
 
 use OpenConext\UserLifecycle\Application\Query\FindUserInformationQuery;
+use OpenConext\UserLifecycle\Domain\Client\InformationResponseCollectionInterface;
 use OpenConext\UserLifecycle\Domain\Client\InformationResponseInterface;
 use OpenConext\UserLifecycle\Domain\Service\InformationServiceInterface;
 
@@ -33,7 +34,7 @@ class FindUserInformationQueryHandler implements FindUserInformationQueryHandler
 
     public function handle(
         FindUserInformationQuery $query,
-    ): InformationResponseInterface {
+    ): InformationResponseCollectionInterface {
         return $this->informationService->readInformationFor($query->getCollabPersonId());
     }
 }

--- a/src/OpenConext/UserLifecycle/Application/QueryHandler/FindUserInformationQueryHandlerInterface.php
+++ b/src/OpenConext/UserLifecycle/Application/QueryHandler/FindUserInformationQueryHandlerInterface.php
@@ -21,11 +21,12 @@ declare(strict_types = 1);
 namespace OpenConext\UserLifecycle\Application\QueryHandler;
 
 use OpenConext\UserLifecycle\Application\Query\FindUserInformationQuery;
+use OpenConext\UserLifecycle\Domain\Client\InformationResponseCollectionInterface;
 use OpenConext\UserLifecycle\Domain\Client\InformationResponseInterface;
 
 interface FindUserInformationQueryHandlerInterface
 {
     public function handle(
         FindUserInformationQuery $query,
-    ): InformationResponseInterface;
+    ): InformationResponseCollectionInterface;
 }

--- a/src/OpenConext/UserLifecycle/Domain/Service/InformationServiceInterface.php
+++ b/src/OpenConext/UserLifecycle/Domain/Service/InformationServiceInterface.php
@@ -20,14 +20,11 @@ declare(strict_types = 1);
 
 namespace OpenConext\UserLifecycle\Domain\Service;
 
-use OpenConext\UserLifecycle\Domain\Client\InformationResponseInterface;
+use OpenConext\UserLifecycle\Domain\Client\InformationResponseCollectionInterface;
 
 interface InformationServiceInterface
 {
-    /**
-     * @return InformationResponseInterface
-     */
     public function readInformationFor(
         string $personId,
-    );
+    ): InformationResponseCollectionInterface;
 }


### PR DESCRIPTION
Prior to this change, an error would be thrown when the UserInformation would be fetched. This change corrects the return types so the error is fixed.

See https://github.com/OpenConext/OpenConext-user-lifecycle/issues/72